### PR TITLE
Result

### DIFF
--- a/.github/workflows/google-test.yml
+++ b/.github/workflows/google-test.yml
@@ -19,4 +19,4 @@ jobs:
       run: cmake --build build
 
     - name: Test
-      run: ./build/example_test
+      run: ./build/webserv_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.26)
-project(example_project) # TODO Rename project
+project(webserv)
 
-set(PROGRAM example_test) # TODO Rename program
+set(PROGRAM webserv_test)
 set(GTEST_VERSION 1.12.1)
 
 include(FetchContent)
@@ -25,7 +25,8 @@ add_executable(${PROGRAM}
 target_link_libraries(${PROGRAM}
         gtest_main
 )
-target_include_directories(${PROGRAM}
-        PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-)
+file(GLOB_RECURSE INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/src/*")
+foreach(DIR ${INCLUDE_DIRS})
+    get_filename_component(DIR_PATH ${DIR} PATH)
+    target_include_directories(${PROGRAM} PRIVATE ${DIR_PATH})
+endforeach()

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BASE_DIR := $(CURDIR)
 BUILD_DIR := build
 BUILD_PATH := $(BASE_DIR)/$(BUILD_DIR)
-TEST_EXE_PATH := $(BUILD_PATH)/example_test # Rename test executable
+TEST_EXE_PATH := $(BUILD_PATH)/webserv_test
 
 # Default target
 .PHONY: all

--- a/src/utils/result.hpp
+++ b/src/utils/result.hpp
@@ -78,6 +78,8 @@ private:
   OkT value_;
   ErrT error_;
   bool has_value_;
+
+  Result() : value_(OkT()), error_(ErrT()), has_value_(false) {}
 };
 
 namespace details {
@@ -93,13 +95,6 @@ public:
 
   Value(const Value &other) : value_(other.value_) {}
 
-  Value &operator=(const Value &other) {
-    if (this == &other) {
-      return *this;
-    }
-    value_ = other.value_;
-  }
-
   ~Value() {}
 
   template <typename U, typename F> operator Result<U, F>() const {
@@ -108,6 +103,13 @@ public:
 
 private:
   T value_;
+
+  Value &operator=(const Value &other) {
+    if (this == &other) {
+      return *this;
+    }
+    value_ = other.value_;
+  }
 };
 
 template <typename E> class Error {
@@ -116,23 +118,21 @@ public:
 
   Error(const Error &other) : error_(other.error_) {}
 
-  Error &operator=(const Error &other) {
-    if (this == &other) {
-      return *this;
-    }
-    error_ = other.error_;
-  }
-
   ~Error() {}
 
   template <typename U, typename F> operator Result<U, F>() const {
     return Result<U, F>(U(), error_, /* has_value= */ false);
   }
 
-  E error() const { return error_; }
-
 private:
   E error_;
+
+  Error &operator=(const Error &other) {
+    if (this == &other) {
+      return *this;
+    }
+    error_ = other.error_;
+  }
 };
 
 } // namespace details

--- a/src/utils/result.hpp
+++ b/src/utils/result.hpp
@@ -6,6 +6,24 @@
 /*
  * RustライクなResultクラス
  * 値とエラーのどちらか一方を持つ
+ *
+ * Usage:
+ * Result<std::string, std::string> ProcessSomething(bool is_success) {
+ *    if (is_success) {
+ *      return Ok("Success");
+ *    }
+ *    return Err("Failure");
+ *  }
+ *
+ *  int main() {
+ *    Result<std::string, std::string> result = ProcessSomething(true);
+ *    if (result.IsOk()) {
+ *      std::cout << "Result: " << result.Unwrap() << std::endl;
+ *    } else {
+ *      std::cout << "Error: " << result.UnwrapErr() << std::endl;
+ *    }
+ *    return 0;
+ *  }
  */
 
 template <typename OkT, typename ErrT> class Result {

--- a/src/utils/result.hpp
+++ b/src/utils/result.hpp
@@ -1,0 +1,136 @@
+#ifndef WEBSERV_SRC_UTILS_RESULT_HPP
+#define WEBSERV_SRC_UTILS_RESULT_HPP
+
+#include <stdexcept>
+
+/*
+ * RustライクなResultクラス
+ * 値とエラーのどちらか一方を持つ
+ */
+
+template <typename OkT, typename ErrT> class Result {
+public:
+  Result(OkT value, ErrT error, bool has_value)
+      : value_(value), error_(error), has_value_(has_value) {}
+
+  Result(const Result &other)
+      : value_(other.value_), error_(other.error_),
+        has_value_(other.has_value_) {}
+
+  Result &operator=(const Result &other) {
+    if (this == &other) {
+      return *this;
+    }
+    value_ = other.value_;
+    error_ = other.error_;
+    has_value_ = other.has_value_;
+  }
+
+  ~Result() {}
+
+  bool operator<(const Result &other) const {
+    if (has_value_) {
+      return value_ < other.value_;
+    } else {
+      return error_ < other.error_;
+    }
+  }
+
+  // Errに対してUnwrapを呼ぶと例外を投げる
+  OkT Unwrap() const {
+    if (!IsOk()) {
+      throw std::runtime_error("Result does not have a value");
+    }
+    return value_;
+  }
+
+  // Okに対してUnwrapErrを呼ぶと例外を投げる
+  ErrT UnwrapErr() const {
+    if (!IsErr()) {
+      throw std::runtime_error("Result does not have an error");
+    }
+    return error_;
+  }
+
+  bool IsOk() const { return has_value_; }
+
+  bool IsErr() const { return !has_value_; }
+
+private:
+  OkT value_;
+  ErrT error_;
+  bool has_value_;
+};
+
+namespace details {
+
+/*
+ * ValueとErrorクラスはResultクラスに変換するためのキャスト演算子を持つ
+ * これによってResultクラスを生成するためのヘルパー関数を作成できる
+ */
+
+template <typename T> class Value {
+public:
+  explicit Value(T value) : value_(value) {}
+
+  Value(const Value &other) : value_(other.value_) {}
+
+  Value &operator=(const Value &other) {
+    if (this == &other) {
+      return *this;
+    }
+    value_ = other.value_;
+  }
+
+  ~Value() {}
+
+  template <typename U, typename F> operator Result<U, F>() const {
+    return Result<U, F>(value_, F(), /* has_value= */ true);
+  }
+
+private:
+  T value_;
+};
+
+template <typename E> class Error {
+public:
+  explicit Error(E error) : error_(error) {}
+
+  Error(const Error &other) : error_(other.error_) {}
+
+  Error &operator=(const Error &other) {
+    if (this == &other) {
+      return *this;
+    }
+    error_ = other.error_;
+  }
+
+  ~Error() {}
+
+  template <typename U, typename F> operator Result<U, F>() const {
+    return Result<U, F>(U(), error_, /* has_value= */ false);
+  }
+
+  E error() const { return error_; }
+
+private:
+  E error_;
+};
+
+} // namespace details
+
+/*
+ * Resultクラスを使いやすくするためのヘルパー関数
+ * OkとErr関数はValueとErrorクラスを生成するための関数
+ * これによってテンプレートパラメータを指定しなくても暗黙の型変換でResultクラスを生成できる
+ */
+
+template <typename T> details::Value<T> Ok(T value) {
+  return details::Value<T>(value);
+}
+
+template <typename E> details::Error<E> Err(E error) {
+  return details::Error<E>(error);
+}
+
+#endif // WEBSERV_SRC_UTILS_RESULT_HPP

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -3,24 +3,114 @@
 #include "result.hpp"
 
 namespace {
-Result<std::string, std::string> IsEven(int a) {
-  if (a % 2 != 0) {
-    return Err("Not an even number");
+Result<std::string, std::string> ProcessSomething(bool is_success) {
+  if (is_success) {
+    return Ok("Success");
   }
-  return Ok("Even number");
+  return Err("Failure");
+}
+
+Result<int, std::string> OpenFile(bool is_success) {
+  if (is_success) {
+    return Ok(10);
+  }
+  return Err("File not found");
 }
 } // namespace
 
+/*
+ * Resultクラスのテスト
+ */
+
+// コンストラクタ
+TEST(ResultTest, ResultConstructor) {
+  Result<int, std::string> result(10, "", true);
+  ASSERT_EQ(result.Unwrap(), 10);
+}
+
+// コピーコンストラクタ
+TEST(ResultTest, ResultCopyConstructor) {
+  Result<int, std::string> result(10, "", true);
+  Result<int, std::string> result2(result);
+  ASSERT_EQ(result2.Unwrap(), 10);
+}
+
+// コピー代入演算子
+TEST(ResultTest, ResultCopyAssignmentOperator) {
+  Result<int, std::string> result(10, "", true);
+  Result<int, std::string> result2 = result;
+  ASSERT_EQ(result2.Unwrap(), 10);
+}
+
 // 処理が成功した場合
-TEST(ResultTest, IsEven) {
-  Result<std::string, std::string> result = IsEven(10);
+// OkTとErrTが同じ型の場合
+TEST(ResultTest, ResultSuccessWithSameType) {
+  Result<std::string, std::string> result = ProcessSomething(true);
   ASSERT_TRUE(result.IsOk());
-  ASSERT_EQ(result.Unwrap(), "Even number");
+  ASSERT_EQ(result.Unwrap(), "Success");
+}
+
+// OkTとErrTが異なる型の場合
+TEST(ResultTest, ResultSuccessWithDifferentType) {
+  Result<int, std::string> result = OpenFile(true);
+  ASSERT_TRUE(result.IsOk());
+  ASSERT_EQ(result.Unwrap(), 10);
 }
 
 // 処理が失敗した場合
-TEST(ResultTest, IsNotEven) {
-  Result<std::string, std::string> result = IsEven(11);
+// OkTとErrTが同じ型の場合
+TEST(ResultTest, ResultFailureWithSameType) {
+  Result<std::string, std::string> result = ProcessSomething(false);
   ASSERT_TRUE(result.IsErr());
-  ASSERT_EQ(result.UnwrapErr(), "Not an even number");
+  ASSERT_EQ(result.UnwrapErr(), "Failure");
+}
+
+// OkTとErrTが異なる型の場合
+TEST(ResultTest, ResultFailureWithDifferentType) {
+  Result<int, std::string> result = OpenFile(false);
+  ASSERT_TRUE(result.IsErr());
+  ASSERT_EQ(result.UnwrapErr(), "File not found");
+}
+
+// IsErrがtrueの場合にUnwrapを呼ぶと例外を投げる
+TEST(ResultTest, CallUnwrapOnErrCauseException) {
+  Result<std::string, std::string> result = ProcessSomething(false);
+  ASSERT_TRUE(result.IsErr());
+  ASSERT_THROW(result.Unwrap(), std::runtime_error);
+  // 例外のメッセージを確認する
+  try {
+    result.Unwrap();
+  } catch (const std::runtime_error &e) {
+    ASSERT_STREQ(e.what(), "Result does not have a value");
+  }
+}
+
+// IsOkがtrueの場合にUnwrapErrを呼ぶと例外を投げる
+TEST(ResultTest, CallUnwrapErrOnOkCauseException) {
+  Result<std::string, std::string> result = ProcessSomething(false);
+  ASSERT_NO_THROW(result.UnwrapErr());
+  // 例外のメッセージを確認する
+  try {
+    result.UnwrapErr();
+  } catch (const std::runtime_error &e) {
+    ASSERT_STREQ(e.what(), "Result does not have an error");
+  }
+}
+
+/*
+ * Ok, Errヘルパー関数のテスト
+ */
+
+// Okヘルパー関数のテスト
+TEST(ResultTest, OkHelper) {
+  Result<int, std::string> result = Ok(10);
+  ASSERT_TRUE(result.IsOk());
+  ASSERT_EQ(result.Unwrap(), 10);
+}
+
+// Errヘルパー関数のテスト
+TEST(ResultTest, ErrHelper) {
+  Result<int, std::string> result = Err("Error");
+  ASSERT_TRUE(result.IsErr());
+  ASSERT_EQ(result.UnwrapErr(), "Error");
 }

--- a/test/result_test.cpp
+++ b/test/result_test.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include "result.hpp"
+
+namespace {
+Result<std::string, std::string> IsEven(int a) {
+  if (a % 2 != 0) {
+    return Err("Not an even number");
+  }
+  return Ok("Even number");
+}
+} // namespace
+
+// 処理が成功した場合
+TEST(ResultTest, IsEven) {
+  Result<std::string, std::string> result = IsEven(10);
+  ASSERT_TRUE(result.IsOk());
+  ASSERT_EQ(result.Unwrap(), "Even number");
+}
+
+// 処理が失敗した場合
+TEST(ResultTest, IsNotEven) {
+  Result<std::string, std::string> result = IsEven(11);
+  ASSERT_TRUE(result.IsErr());
+  ASSERT_EQ(result.UnwrapErr(), "Not an even number");
+}


### PR DESCRIPTION
## 1. issue number
#6 

## 2. やったこと
resultクラスの実装。
Resultクラスに加えて、ValueとErrorクラスを実装した
ValueとErrorは、暗黙の型変換でResultクラスに変換するための媒介
これをすることで`Ok("success")`のようにテンプレートパラメータの指定なしでResultを返せる

ValueとErrorの暗黙の型変換を使わないと、例えば`Ok<int, std::string>("success")`みたいやつを毎回書かないといけなくなる

## 3. やらないこと
`OkT`が`void`の時のテンプレートの特殊化、あとは型が参照の時の対応とかは別PRでやる

## 4. 動作確認
Resultの公開メソッド、Ok, Err関数の動作についてテストした
 
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
ValueとErrorは内部で使うだけで実際にユーザがインスタンス化したりすることはないから、detailっていうnamespaceに入れちゃってる