### PR TITLE
23 config fix

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -2,9 +2,7 @@
 
 Config::Config() {}
 
-Config::Config(const Config &other){
-  *this = other;
-}
+Config::Config(const Config &other) { *this = other; }
 
 Config::~Config() {}
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -14,7 +14,7 @@ Config &Config::operator=(const Config &other) {
   return *this;
 }
 
-void Config::addServer(const ServerContext &server) {
+void Config::AddServer(const ServerContext &server) {
   server_.push_back(server);
 }
 

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -18,13 +18,8 @@ Config &Config::operator=(const Config &other) {
   return *this;
 }
 
-// パーススタート
-void Config::ParseFile() {
-  std::ifstream inf(file_);
-  if (!inf.is_open()) {
-    throw std::invalid_argument("File could not open: " + file_);
-  }
-  server_ = ConfigParser::Parse(inf);
+void Config::addServer(const ServerContext &server) {
+  server_.push_back(server);
 }
 
 const std::vector<ServerContext> &Config::GetServer() const { return server_; }

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -1,11 +1,10 @@
 #include "config.hpp"
 
-Config::Config() : file_(DEFAULTCONF) {}
+Config::Config() {}
 
-Config::Config(const std::string &file) : file_(file) {}
-
-Config::Config(const Config &other)
-    : file_(other.file_), server_(other.server_) {}
+Config::Config(const Config &other){
+  *this = other;
+}
 
 Config::~Config() {}
 
@@ -13,7 +12,6 @@ Config &Config::operator=(const Config &other) {
   if (this == &other) {
     return *this;
   }
-  file_ = other.file_;
   server_ = other.server_;
   return *this;
 }

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -17,8 +17,8 @@ class Config {
   Config(const Config &other);
   ~Config();
   Config &operator=(const Config &other);
-  void ParseFile();
   const std::vector<ServerContext> &GetServer() const;
+  void addServer(const ServerContext &);
 
  private:
   std::string file_;

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -8,12 +8,10 @@
 #include "config_parser.hpp"
 #include "server_context.hpp"
 
-#define DEFAULTCONF "conf/default.conf"
-
+class ConfigParser;
 class Config {
  public:
   Config();
-  Config(const std::string &);
   Config(const Config &other);
   ~Config();
   Config &operator=(const Config &other);
@@ -21,7 +19,6 @@ class Config {
   void addServer(const ServerContext &);
 
  private:
-  std::string file_;
   std::vector<ServerContext> server_;
 };
 

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -16,7 +16,7 @@ class Config {
   ~Config();
   Config &operator=(const Config &other);
   const std::vector<ServerContext> &GetServer() const;
-  void addServer(const ServerContext &);
+  void AddServer(const ServerContext &);
 
  private:
   std::vector<ServerContext> server_;

--- a/src/config/config_parser.cpp
+++ b/src/config/config_parser.cpp
@@ -1,6 +1,6 @@
 #include "config_parser.hpp"
 
-Config Parse(const std::string &file) {
+Config ConfigParser::Parse(const std::string &file) {
   Config config;
   std::vector<ServerContext> server;
   std::string line;

--- a/src/config/config_parser.cpp
+++ b/src/config/config_parser.cpp
@@ -1,9 +1,13 @@
 #include "config_parser.hpp"
 
-std::vector<ServerContext> ConfigParser::Parse(std::ifstream &inf) {
+Config Parse(const std::string &file) {
+  Config config;
   std::vector<ServerContext> server;
   std::string line;
-
+  std::ifstream inf(file);
+  if (!inf.is_open()) {
+    throw std::invalid_argument("File could not open: " + file);
+  }
   while (std::getline(inf, line)) {
     std::stringstream ss(line);
     std::string key;
@@ -12,10 +16,10 @@ std::vector<ServerContext> ConfigParser::Parse(std::ifstream &inf) {
     if (key.empty()) continue;
     ss >> value;
     if (key + value == "server{" && ss.get() == std::char_traits<char>::eof())
-      server.push_back(ServerParser::ParseServer(inf));
+      config.addServer(ServerParser::ParseServer(inf));
     else {
       throw std::invalid_argument("Invalid key: " + line);
     }
   }
-  return server;
+  return config;
 }

--- a/src/config/config_parser.cpp
+++ b/src/config/config_parser.cpp
@@ -1,5 +1,7 @@
 #include "config_parser.hpp"
 
+const std::string ConfigParser::default_file_ = "./conf/default.conf";
+
 Config ConfigParser::Parse(const std::string &file) {
   Config config;
   std::vector<ServerContext> server;
@@ -16,7 +18,7 @@ Config ConfigParser::Parse(const std::string &file) {
     if (key.empty()) continue;
     ss >> value;
     if (key + value == "server{" && ss.get() == std::char_traits<char>::eof())
-      config.addServer(ServerParser::ParseServer(inf));
+      config.AddServer(ServerParser::ParseServer(inf));
     else {
       throw std::invalid_argument("Invalid key: " + line);
     }

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -12,6 +12,8 @@
 #include "server_context.hpp"
 #include "server_parser.hpp"
 
+class Config;
+
 class ConfigParser {
  public:
   static Config Parse(const std::string &);

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -17,6 +17,7 @@ class Config;
 class ConfigParser {
  public:
   static Config Parse(const std::string &);
+  static const std::string default_file_;
 };
 
 #endif

--- a/src/config/config_parser.hpp
+++ b/src/config/config_parser.hpp
@@ -8,12 +8,13 @@
 #include <string>
 #include <vector>
 
+#include "config.hpp"
 #include "server_context.hpp"
 #include "server_parser.hpp"
 
 class ConfigParser {
  public:
-  static std::vector<ServerContext> Parse(std::ifstream &);
+  static Config Parse(const std::string &);
 };
 
 #endif

--- a/src/config/location_context.cpp
+++ b/src/config/location_context.cpp
@@ -57,8 +57,8 @@ const std::map<std::string, std::string>& LocationContext::GetErrorPage()
 void LocationContext::SetCanAutoIndex(bool can_auto_index) {
   can_auto_index_ = can_auto_index;
 }
-void LocationContext::SetLimitClientBody(int limit_client_body_bytes_) {
-  limit_client_body_bytes_ = limit_client_body_bytes_;
+void LocationContext::SetLimitClientBody(int limit_client_body_bytes) {
+  limit_client_body_bytes_ = limit_client_body_bytes;
 }
 void LocationContext::SetReturn(const std::string& ret) { return_ = ret; }
 void LocationContext::SetAlias(const std::string& alias) { alias_ = alias; }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,21 @@
 
 #include "config.hpp"
 #include "config_parser.hpp"
+#include "logger.hpp"
 
-int main() {
+int main(int ac, char **av) {
+  std::string config_file;
+  if (ac == 1)
+    config_file = ConfigParser::default_file_;
+  else if (ac == 2)
+    config_file = av[1];
+  else {
+    Logger::Error() << "Invalid argument." << std::endl;
+    return 0;
+  }
+  Logger::Info() << "Reading " << config_file << std::endl;
   try {
-    Config config = ConfigParser::Parse("./conf/default.conf");
+    Config config = ConfigParser::Parse(config_file);
     std::cout << config << std::endl;
   } catch (std::exception &e) {
     std::cerr << e.what() << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,12 @@
 #include <iostream>
 
 #include "config.hpp"
+#include "config_parser.hpp"
 
 int main() {
-  Config config;
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("./conf/default.conf");
+    std::cout << config << std::endl;
   } catch (std::exception &e) {
     std::cerr << e.what() << std::endl;
   }

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
 #include "config.hpp"
+#include "config_parser.hpp"
 
 TEST(ConfigTest, DefaultPath) {
-  Config config("test/conf_test/default.conf");
-  config.ParseFile();
+  Config config = ConfigParser::Parse("test/conf_test/default.conf");
   ASSERT_EQ(config.GetServer().size(), 1);
   ASSERT_EQ(config.GetServer()[0].GetIp(), "127.0.0.1");
   ASSERT_EQ(config.GetServer()[0].GetRoot(), "docs/fusion_web/");
@@ -101,90 +101,80 @@ TEST(ConfigTest, DefaultPath) {
 }
 
 TEST(ConfigTest, TooLargePortTest){
-  Config config("test/conf_test/too_large_port.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/too_large_port.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "20000000000000 is too large");
   }
 }
 
 TEST(ConfigTest, NotNumberPortTest){
-  Config config("test/conf_test/not_num_port.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/not_num_port.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "200a is not a number");
   }
 }
 
 TEST(ConfigTest, InvalidServerTest){
-  Config config("test/conf_test/invalid_server.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/invalid_server.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Invalid key: servera {");
   }
 }
 
 TEST(ConfigTest, NoFileTest){
-  Config config("test/conf_test/no_file.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/no_file.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "File could not open: test/conf_test/no_file.conf");
   }
 }
 
 TEST(ConfigTest, InvalidLocationKeyTest){
-  Config config("test/conf_test/invalid_location_key.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/invalid_location_key.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Invalid location key: tokazaki");
   }
 }
 
 TEST(ConfigTest, InvalidLocationValueTest){
-  Config config("test/conf_test/invalid_location_value.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/invalid_location_value.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Invalid location value: /usr/share/nginx/html /usr/share/nginx/html");
   }
 }
 
 TEST(ConfigTest, LocationSyntaxErrorTest){
-  Config config("test/conf_test/location_syntax_error.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/location_syntax_error.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Syntax error: semicolon: \t\troot /usr/share/nginx/html");
   }
 }
 
 TEST(ConfigTest, ServerSyntaxErrorTest){
-  Config config("test/conf_test/server_syntax_error.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/server_syntax_error.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Syntax error: 	location / ");
   }
 }
 
 TEST(ConfigTest, InvalidServerKeyTest){
-  Config config("test/conf_test/invalid_server_key.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/invalid_server_key.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Invalid server key: tkuramot");
   }
 }
 
 TEST(ConfigTest, InvalidServerValueTest){
-  Config config("test/conf_test/invalid_server_value.conf");
   try {
-    config.ParseFile();
+    Config config = ConfigParser::Parse("test/conf_test/invalid_server_value.conf");
   } catch (std::exception &e) {
     ASSERT_STREQ(e.what(), "Invalid server value: kuramoto okazaki");
   }


### PR DESCRIPTION
## 1. issue number
#23 

## 2. やったこと
configパースの位置を変更

## 3. やらないこと


## 4. 動作確認
test
  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
ConfigParserの返り値をConfig自体にして、そのまま持つようにした。
返り値として扱うために、コピーコンストラクタ
それをmainで代入するために代入演算子は必要であった。