### PR TITLE
add flag to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.26)
-project(webserv)
+project(webserv LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-Wall -Wextra -Werror)
 
 set(PROGRAM webserv_test)
 set(GTEST_VERSION 1.12.1)

--- a/src/utils/result.hpp
+++ b/src/utils/result.hpp
@@ -168,9 +168,12 @@ class Value<void> {
  public:
   Value() {}
 
-  Value(const Value &other) {}
+  Value(const Value &other) { (void)other; }
 
-  Value &operator=(const Value &other) { return *this; }
+  Value &operator=(const Value &other) {
+    (void)other;
+    return *this;
+  }
 
   ~Value() {}
 


### PR DESCRIPTION
## 1. issue number
#19 #27

## 2. やったこと
cmakeでテストを作成するとき、
-Wall -Wextra -Werrorをつけるようにした。
C++の標準をc++98で指定し、指定した標準がサポートされていない場合にはコンパイルエラーを発生させる。
言語をc++であることを明記した。

それに伴い、コンパイルエラーが出たunused parameterを直した。

## 3. やらないこと


## 4. 動作確認
make test でも　unused parameterのエラーが出た。
  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
