### PR TITLE
ローカルでビルドテストできるようにする close #87

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:24.04
+
+WORKDIR /app
+
+RUN set -eux \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+  make \
+  build-essential
+
+ENTRYPOINT ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ RUN set -eux \
   build-essential
 
 ENTRYPOINT ["bash"]
+

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,13 @@ test:
 	@# Execute the test
 	@$(TEST_EXE_PATH) || exit 1
 
+# CI -+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++#
+.PHONY: build
+
+ci/build:
+	docker build -t webserv .
+	docker run --rm -it -v $(CURDIR):/app webserv -c make re
+
 # Clean log file -+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++#
 .PHONY: logclean
 

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test:
 
 ci/build:
 	docker build -t webserv .
-	docker run --rm -it -v $(CURDIR):/app webserv -c make re
+	docker run --rm -it -v $(CURDIR):/app webserv -c "make re && make fclean"
 
 # Clean log file -+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++#
 .PHONY: logclean


### PR DESCRIPTION
## 1. issue number
#87 

## 2. やったこと
ローカルでビルドテストできるようにする
`make ci/build`でDockerを使ってビルドテストできるようにする

## 3. やらないこと


## 4. 動作確認

  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
