### PR TITLE
116 hostportserver nameでsearchできるようにする

### DIFF
--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -11,10 +11,10 @@ void Config::AddServer(const ServerContext &server) {
 const std::vector<ServerContext> &Config::GetServer() { return server_; }
 
 const ServerContext &Config::SearchServer(const std::string &port,
-                                          const std::string &server_name) {
+                                          const std::string &ip, const std::string &server_name) {
   long ret = -1;
   for (unsigned int i = 0; i < server_.size(); ++i) {
-    if (server_.at(i).HavePort(port) &&
+    if (server_.at(i).HavePort(port) && ip == server_.at(i).GetIp() &&
         (server_.at(i).HaveServerName(server_name) || ret == -1))
       ret = i;
   }

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -11,7 +11,8 @@ void Config::AddServer(const ServerContext &server) {
 const std::vector<ServerContext> &Config::GetServer() { return server_; }
 
 const ServerContext &Config::SearchServer(const std::string &port,
-                                          const std::string &ip, const std::string &server_name) {
+                                          const std::string &ip,
+                                          const std::string &server_name) {
   long ret = -1;
   for (unsigned int i = 0; i < server_.size(); ++i) {
     if (server_.at(i).HavePort(port) && ip == server_.at(i).GetIp() &&

--- a/src/config/config.cpp
+++ b/src/config/config.cpp
@@ -18,11 +18,12 @@ void Config::AddServer(const ServerContext &server) {
 const std::vector<ServerContext> &Config::GetServer() const { return server_; }
 
 const ServerContext &Config::SearchServer(
-    const std::string &port, const std::string &ip, const std::string &server_name) const {
+    const std::string &port, const std::string &ip,
+    const std::string &server_name) const {
   std::vector<ServerContext>::const_iterator ans = server_.end();
   std::vector<ServerContext>::const_iterator it = server_.begin();
   for (; it != server_.end(); ++it) {
-    if (it->HavePort(port) &&　ip == it->GetIp() &&
+    if (it->HavePort(port) && ip == it->GetIp() &&
         (it->HaveServerName(server_name) || ans == server_.end()))
       ans = it;
   }

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -15,7 +15,7 @@ class Config {
   static void AddServer(const ServerContext &server);
   static const std::vector<ServerContext> &GetServer();
   static const ServerContext &SearchServer(const std::string &port,
-                                           const std::string &server_name);
+                                           const std::string &ip, const std::string &server_name);
 
  private:
   Config();

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -17,8 +17,8 @@ class Config {
   void AddServer(const ServerContext &server);
   const std::vector<ServerContext> &GetServer() const;
   const ServerContext &SearchServer(const std::string &port,
-                                           const std::string &ip,
-                                           const std::string &server_name) const;
+                                    const std::string &ip,
+                                    const std::string &server_name) const;
 
  private:
   Config &operator=(const Config &other);

--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -15,7 +15,8 @@ class Config {
   static void AddServer(const ServerContext &server);
   static const std::vector<ServerContext> &GetServer();
   static const ServerContext &SearchServer(const std::string &port,
-                                           const std::string &ip, const std::string &server_name);
+                                           const std::string &ip,
+                                           const std::string &server_name);
 
  private:
   Config();

--- a/src/server/accept.cpp
+++ b/src/server/accept.cpp
@@ -1,7 +1,7 @@
 #include "accept.hpp"
 
-Accept::Accept(int fd, const std::string &port)
-    : AIOTask(fd, POLLIN), port_(port) {}
+Accept::Accept(int fd, const std::string &port, const std::string &ip)
+    : AIOTask(fd, POLLIN), port_(port), ip_(ip) {}
 
 Accept::~Accept() {}
 
@@ -20,8 +20,9 @@ Result<int, std::string> Accept::Execute() {
   }
   Logger::Info() << port_ << " : 接続しました" << std::endl;
   // TODO: IOTaskManagerクラスとReadRequestFromClientクラスの実装
-  //  IOTaskManager::AddTask(new ReadRequestFromClient(client_sock, port_));
+  //  IOTaskManager::AddTask(new ReadRequestFromClient(client_sock, port_, ip_));
   return Ok(0);
 }
 
 const std::string &Accept::GetPort() const { return port_; }
+const std::string &Accept::GetIp() const { return ip_; }

--- a/src/server/accept.cpp
+++ b/src/server/accept.cpp
@@ -20,7 +20,8 @@ Result<int, std::string> Accept::Execute() {
   }
   Logger::Info() << port_ << " : 接続しました" << std::endl;
   // TODO: IOTaskManagerクラスとReadRequestFromClientクラスの実装
-  //  IOTaskManager::AddTask(new ReadRequestFromClient(client_sock, port_, ip_));
+  //  IOTaskManager::AddTask(new ReadRequestFromClient(client_sock, port_,
+  //  ip_));
   return Ok(0);
 }
 

--- a/src/server/accept.hpp
+++ b/src/server/accept.hpp
@@ -16,16 +16,18 @@
 
 class Accept : public AIOTask {
  public:
-  Accept(int fd, const std::string &);
+  Accept(int fd, const std::string &port, const std::string &ip);
   virtual ~Accept();
   virtual Result<int, std::string> Execute();
   const std::string &GetPort() const;
+  const std::string &GetIp() const;
 
  private:
   Accept();
   Accept(const Accept &other);
   Accept &operator=(const Accept &other);
   std::string port_;
+  std::string ip_;
 };
 
 #endif

--- a/src/server/read_request_from_client.cpp
+++ b/src/server/read_request_from_client.cpp
@@ -1,6 +1,7 @@
 #include "read_request_from_client.hpp"
 
-ReadRequestFromClient::ReadRequestFromClient(int fd, const std::string &port, const std::string &ip) {
+ReadRequestFromClient::ReadRequestFromClient(int fd, const std::string &port,
+                                             const std::string &ip) {
   fd_ = fd;
   event_ = POLLIN;
   port_ = port;
@@ -27,8 +28,8 @@ Result<int, std::string> ReadRequestFromClient::Execute() {
   //    IOTaskManager::AddTask(new WriteResponseToClient write_response(fd_,
   //    badrequest_response));
   //  } else {
-  //    HTTPResponse *response = RequestHandler::Handle(result.Unwrap(), port_, ip_);
-  //    IOTaskManager::AddTask(new WriteResponseToClient(fd_, response));
+  //    HTTPResponse *response = RequestHandler::Handle(result.Unwrap(), port_,
+  //    ip_); IOTaskManager::AddTask(new WriteResponseToClient(fd_, response));
   //  }
   Logger::Info() << port_ << " : "
                  << "レスポンスのタスクを追加しました" << std::endl;

--- a/src/server/read_request_from_client.cpp
+++ b/src/server/read_request_from_client.cpp
@@ -1,9 +1,10 @@
 #include "read_request_from_client.hpp"
 
-ReadRequestFromClient::ReadRequestFromClient(int fd, const std::string &port) {
+ReadRequestFromClient::ReadRequestFromClient(int fd, const std::string &port, const std::string &ip) {
   fd_ = fd;
   event_ = POLLIN;
   port_ = port;
+  ip_ = ip;
   // parser_ = RequestParser();
 }
 
@@ -26,7 +27,7 @@ Result<int, std::string> ReadRequestFromClient::Execute() {
   //    IOTaskManager::AddTask(new WriteResponseToClient write_response(fd_,
   //    badrequest_response));
   //  } else {
-  //    HTTPResponse *response = RequestHandler::Handle(result.Unwrap());
+  //    HTTPResponse *response = RequestHandler::Handle(result.Unwrap(), port_, ip_);
   //    IOTaskManager::AddTask(new WriteResponseToClient(fd_, response));
   //  }
   Logger::Info() << port_ << " : "
@@ -35,3 +36,4 @@ Result<int, std::string> ReadRequestFromClient::Execute() {
 }
 
 const std::string &ReadRequestFromClient::GetPort() const { return port_; }
+const std::string &ReadRequestFromClient::GetIp() const { return ip_; }

--- a/src/server/read_request_from_client.hpp
+++ b/src/server/read_request_from_client.hpp
@@ -15,16 +15,18 @@
 
 class ReadRequestFromClient : public AIOTask {
  public:
-  ReadRequestFromClient(int fd, const std::string &port);
+  ReadRequestFromClient(int fd, const std::string &port, const std::string &ip);
   virtual ~ReadRequestFromClient();
   virtual Result<int, std::string> Execute();
   const std::string &GetPort() const;
+  const std::string &GetIp() const;
 
  private:
   ReadRequestFromClient();
   ReadRequestFromClient(const ReadRequestFromClient &other);
   ReadRequestFromClient &operator=(const ReadRequestFromClient &other);
   std::string port_;
+  std::string ip_;
   // RequestParser parser_;
 };
 

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -20,7 +20,8 @@ void Server::run() {
       if (listen_port[*port_it] == false) {
         Result<int, int> result = Listen(*port_it, server_it->GetIp());
         if (result.IsOk()) {
-          // IOTaskManager::AddTask(new Accept(result.Unwrap(), *port_it, server_it->GetIp()));
+          // IOTaskManager::AddTask(new Accept(result.Unwrap(), *port_it,
+          // server_it->GetIp()));
           listen_port[*port_it] = true;
         } else {
           Logger::Error() << "リッスンに失敗しました" << std::endl;
@@ -32,7 +33,8 @@ void Server::run() {
 }
 
 // bind, listenのエラーハンドリングするためにAcceptのコンストラクタから移行する
-Result<int, int> Server::Listen(const std::string &port, const std::string &ip) {
+Result<int, int> Server::Listen(const std::string &port,
+                                const std::string &ip) {
   int sock = socket(AF_INET, SOCK_STREAM, 0);
   struct sockaddr_in addr;
   Result<int, std::string> result = string_utils::StrToI(port);
@@ -40,7 +42,8 @@ Result<int, int> Server::Listen(const std::string &port, const std::string &ip) 
   memset(&addr, 0, sizeof(addr));
   addr.sin_family = AF_INET;
   addr.sin_port = htons(result.Unwrap());
-  //TODO: inet_addrは使用可能ではないため、自作の必要あり　空文字列の場合INADDR_ANYを返してくる
+  // TODO:
+  // inet_addrは使用可能ではないため、自作の必要あり　空文字列の場合INADDR_ANYを返してくる
   addr.sin_addr.s_addr = inet_addr(ip.c_str());
 
   // TODO：errornoを見て処理を変える

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -20,7 +20,8 @@ class Server {
   ~Server();
   Server(const Server &other);
   Server &operator=(const Server &other);
-  static Result<int, int> Listen(const std::string &port, const std::string &ip);
+  static Result<int, int> Listen(const std::string &port,
+                                 const std::string &ip);
 
   // TODO : errornoによって定義していく
   enum Error { kListenError, kBindError };

--- a/src/server/server.hpp
+++ b/src/server/server.hpp
@@ -20,7 +20,7 @@ class Server {
   ~Server();
   Server(const Server &other);
   Server &operator=(const Server &other);
-  static Result<int, int> Listen(const std::string &port);
+  static Result<int, int> Listen(const std::string &port, const std::string &ip);
 
   // TODO : errornoによって定義していく
   enum Error { kListenError, kBindError };

--- a/test/conf_test/search_server.conf
+++ b/test/conf_test/search_server.conf
@@ -19,9 +19,10 @@ server {
 server {
     listen 8002;
     server_name tkuramot;
-    host 127.0.0.1;
+    host 127.0.0.2;
     root docs/fusion_web/;
     index index.html;
     error_page 404 405 error_pages/404.html;
 }
+
 

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -265,12 +265,14 @@ TEST(ConfigTest, DoubleLocationErrorPage) {
 // SerchServer
 TEST(SerchServer, DefaultTest) {
   ConfigParser::Parse("test/conf_test/search_server.conf");
-  const ServerContext &tmp = Config::SearchServer("8002", "");
-  ASSERT_EQ(&Config::GetServer().at(0), &tmp);
-  const ServerContext &tmp1 = Config::SearchServer("8000", "");
+  const ServerContext &tmp = Config::SearchServer("8002", "127.0.0.2", "");
+  ASSERT_EQ(&Config::GetServer().at(2), &tmp);
+  const ServerContext &tmp1 = Config::SearchServer("8000", "127.0.0.1", "");
   ASSERT_EQ(&Config::GetServer().at(1), &tmp1);
-  const ServerContext &tmp2 = Config::SearchServer("8000", "tokazaki");
+  const ServerContext &tmp2 =
+      Config::SearchServer("8000", "127.0.0.1", "tokazaki");
   ASSERT_EQ(&Config::GetServer().at(1), &tmp2);
-  const ServerContext &tmp3 = Config::SearchServer("8002", "tkuramot");
+  const ServerContext &tmp3 =
+      Config::SearchServer("8002", "127.0.0.2", "tkuramot");
   ASSERT_EQ(&Config::GetServer().at(2), &tmp3);
 }

--- a/test/config_test.cpp
+++ b/test/config_test.cpp
@@ -265,14 +265,14 @@ TEST(ConfigTest, DoubleLocationErrorPage) {
 // SerchServer
 TEST(SerchServer, DefaultTest) {
   Config config = ConfigParser::Parse("test/conf_test/search_server.conf");
-  const ServerContext &tmp = Config::SearchServer("8002", "127.0.0.2", "");
-  ASSERT_EQ(&Config::GetServer().at(2), &tmp);
-  const ServerContext &tmp1 = Config::SearchServer("8000", "127.0.0.1", "");
-  ASSERT_EQ(&Config::GetServer().at(1), &tmp1);
+  const ServerContext &tmp = config.SearchServer("8002", "127.0.0.2", "");
+  ASSERT_EQ(&config.GetServer().at(2), &tmp);
+  const ServerContext &tmp1 = config.SearchServer("8000", "127.0.0.1", "");
+  ASSERT_EQ(&config.GetServer().at(1), &tmp1);
   const ServerContext &tmp2 =
-      Config::SearchServer("8000", "127.0.0.1", "tokazaki");
-  ASSERT_EQ(&Config::GetServer().at(1), &tmp2);
+      config.SearchServer("8000", "127.0.0.1", "tokazaki");
+  ASSERT_EQ(&config.GetServer().at(1), &tmp2);
   const ServerContext &tmp3 =
-      Config::SearchServer("8002", "127.0.0.2", "tkuramot");
-  ASSERT_EQ(&Config::GetServer().at(2), &tmp3);
+      config.SearchServer("8002", "127.0.0.2", "tkuramot");
+  ASSERT_EQ(&config.GetServer().at(2), &tmp3);
 }


### PR DESCRIPTION
## 1. issue number
#116

## 2. やったこと
acceptとreadrequestfromclientがipを持つようにして、それも含めてsearchServerできるようにした。

## 3. やらないこと
ipが別だが、同じportの時にうまく動かなくなっている。
#123 で行う
エラーハンドリングも同様
#123　で行う

## 4. 動作確認

  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
