### PR TITLE
134 request parser transfer encoding

### DIFF
--- a/src/http/http_request.cpp
+++ b/src/http/http_request.cpp
@@ -40,7 +40,7 @@ void HTTPRequest::AddHeader(const std::string &key, const std::string &value) {
 }
 
 // body setters
-void HTTPRequest::SetBody(const std::string &body) { body_ = body; }
+void HTTPRequest::AddBody(const std::string &body) { body_ = body_ + body; }
 
 // request line getters
 const std::string &HTTPRequest::GetMethod() const { return method_; }

--- a/src/http/http_request.hpp
+++ b/src/http/http_request.hpp
@@ -17,7 +17,7 @@ class HTTPRequest {
   void SetVersion(const std::string &version);
   void SetHostHeader(const std::string &host_header);
   void AddHeader(const std::string &key, const std::string &value);
-  void SetBody(const std::string &body);
+  void AddBody(const std::string &body);
   const std::string &GetMethod() const;
   const std::string &GetUri() const;
   const std::string &GetProtocol() const;

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -175,7 +175,7 @@ int HTTPRequestParser::SetChunkedBody() {
         return kBadRequest;
       }
       pos = request_line.find("\r\n");
-	  if (pos == std::string::npos) return kNotEnough;
+      if (pos == std::string::npos) return kNotEnough;
       request_line = request_line.substr(pos + 2);
       chunked_state = kNeedChunkedBody;
     }

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -185,8 +185,6 @@ int HTTPRequestParser::SetChunkedBody() {
         chunked_state = kNeedChunkedSize;
         return kOk;
       } else if (pos == chunked_size) {
-        std::cout << ":" << row_line_.substr(0, chunked_size) << std::endl;
-
         request_->AddBody(row_line_.substr(0, chunked_size));
         row_line_ = row_line_.substr(chunked_size + 2);
         chunked_state = kNeedChunkedEnd;

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -135,7 +135,7 @@ int HTTPRequestParser::SetRequestBody() {
   std::string request_line = row_line_;
   size_t pos = 0;
 
-// content-length
+  // content-length
   if (request_->GetHeaders().count("CONTENT-LENGTH") > 0) {
     pos = request_line.find("\r\n");
     if (pos == std::string::npos) pos = request_line.length();
@@ -162,7 +162,7 @@ int HTTPRequestParser::SetChunkedBody() {
   size_t pos = 0;
 
   while (1) {
-	  //sizeが書かれているか確認
+    // sizeが書かれているか確認
     if (chunked_state == kNeedChunkedSize) {
       pos = row_line_.find("\r\n");
       if (pos == 0) return kBadRequest;
@@ -174,11 +174,11 @@ int HTTPRequestParser::SetChunkedBody() {
       row_line_ = row_line_.substr(pos + 2);
       chunked_state = kNeedChunkedBody;
     }
-	//sizeの分だけbodyがあるか確認
+    // sizeの分だけbodyがあるか確認
     if (chunked_state == kNeedChunkedBody) {
       pos = row_line_.find("\r\n");
       if (pos == std::string::npos) return kNotEnough;
-	  //size == 0の時はすぐに\r\nが来て終わる
+      // size == 0の時はすぐに\r\nが来て終わる
       if (pos == 0 && chunked_size == 0) {
         row_line_ = row_line_.substr(chunked_size + 2);
         chunked_state = kNeedChunkedSize;

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -20,6 +20,7 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
     std::string request_line) {
   int return_state;
   row_line_ = row_line_ + request_line;
+  if (row_line_ == "") return Err(kEndParse);
   if (request_ == NULL) request_ = new HTTPRequest();
   // requestlineの内容を確認
   if (parser_state_ == kBeforeProcess) {

--- a/src/http/http_request_parser.hpp
+++ b/src/http/http_request_parser.hpp
@@ -15,7 +15,7 @@ class HTTPRequestParser {
     kBadRequest = 0,
     kNotEnough = 1,
     kOk = 2,
-    kEndHandler = 3,
+    kEndParse = 3,
   };
   HTTPRequestParser();
   ~HTTPRequestParser();

--- a/src/http/http_request_parser.hpp
+++ b/src/http/http_request_parser.hpp
@@ -23,6 +23,11 @@ class HTTPRequestParser {
 
  private:
   enum StatusFlag { kBeforeProcess, kNeedHeader, kEndHeader, kNeedBody };
+  enum chunked_state {
+    kNeedChunkedSize,
+    kNeedChunkedBody,
+    kNeedChunkedEnd,
+  };
   HTTPRequest *request_;
   std::string row_line_;
   int parser_state_;
@@ -39,6 +44,7 @@ class HTTPRequestParser {
   int SetRequestHeaders();
   int SetRequestBody();
   int SetChunkedBody();
+  int BadChunkedBody(int &chunked_state, size_t &chunked_size);
 
   const Result<HTTPRequest *, int> BadRequest();
   const Result<HTTPRequest *, int> OkRequest();

--- a/src/http/http_request_parser.hpp
+++ b/src/http/http_request_parser.hpp
@@ -15,6 +15,7 @@ class HTTPRequestParser {
     kBadRequest = 0,
     kNotEnough = 1,
     kOk = 2,
+    kEndHandler = 3,
   };
   HTTPRequestParser();
   ~HTTPRequestParser();
@@ -26,7 +27,6 @@ class HTTPRequestParser {
   enum chunked_state {
     kNeedChunkedSize,
     kNeedChunkedBody,
-    kNeedChunkedEnd,
   };
   HTTPRequest *request_;
   std::string row_line_;

--- a/src/http/http_request_parser.hpp
+++ b/src/http/http_request_parser.hpp
@@ -38,6 +38,7 @@ class HTTPRequestParser {
   int SetRequestLine();
   int SetRequestHeaders();
   int SetRequestBody();
+  int SetChunkedBody();
 
   const Result<HTTPRequest *, int> BadRequest();
   const Result<HTTPRequest *, int> OkRequest();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,28 +2,54 @@
 
 #include "config.hpp"
 #include "config_parser.hpp"
+#include "http_request_parser.hpp"
 #include "logger.hpp"
 
-int main(int ac, char **av) {
-  std::string config_file;
-  if (ac == 1)
-    config_file = ConfigParser::default_file_;
-  else if (ac == 2)
-    config_file = av[1];
-  else {
-    Logger::Error() << "Invalid argument." << std::endl;
-    return 0;
+void CheckRequest(std::string request, HTTPRequestParser &parser) {
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  if (req.IsErr()) {
+    std::cerr << "Error: " << req.UnwrapErr() << std::endl;
+  } else {
+    std::cout << "Method: " << req.Unwrap()->GetMethod() << std::endl;
+    std::cout << "URI: " << req.Unwrap()->GetUri() << std::endl;
+    std::cout << "Protocol: " << req.Unwrap()->GetProtocol() << std::endl;
+    std::cout << "Version: " << req.Unwrap()->GetVersion() << std::endl;
+    std::cout << "Host: " << req.Unwrap()->GetHostHeader() << std::endl;
+    std::cout << "Body: " << req.Unwrap()->GetBody() << std::endl;
   }
-  Logger::Info() << "Reading " << config_file << std::endl;
-  try {
-    Config config = ConfigParser::Parse(config_file);
-    std::vector<ServerContext> m = config.GetServer();
-    for (std::vector<ServerContext>::const_iterator it = m.begin();
-         it != m.end(); ++it) {
-      std::cout << *it << std::endl;
-    }
-  } catch (std::exception &e) {
-    std::cerr << e.what() << std::endl;
-  }
-  return 0;
+}
+
+int main() {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n\r\n";
+  CheckRequest(request, parser);
+  // CheckRequest("5\r\n", parser);
+  // CheckRequest("hello\r\n", parser);
+  // CheckRequest("\r\n", parser);
+  // CheckRequest("0\r\n", parser);
+  // CheckRequest("\r\n", parser);
+
+  // std::string config_file;
+  // if (ac == 1)
+  //   config_file = ConfigParser::default_file_;
+  // else if (ac == 2)
+  //   config_file = av[1];
+  // else {
+  //   Logger::Error() << "Invalid argument." << std::endl;
+  //   return 0;
+  // }
+  // Logger::Info() << "Reading " << config_file << std::endl;
+  // try {
+  //   Config config = ConfigParser::Parse(config_file);
+  //   std::vector<ServerContext> m = config.GetServer();
+  //   for (std::vector<ServerContext>::const_iterator it = m.begin();
+  //        it != m.end(); ++it) {
+  //     std::cout << *it << std::endl;
+  //   }
+  // } catch (std::exception &e) {
+  //   std::cerr << e.what() << std::endl;
+  // }
+  // return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,10 +20,12 @@ void CheckRequest(std::string request, HTTPRequestParser &parser) {
 }
 
 int main() {
+  std::cout << "Hello, World!" << std::endl;
+  return 0;
   HTTPRequestParser parser;
   std::string request =
       "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
-      "chunked\r\n\r\n\r\n";
+      "chunked\r\n\r\n";
   CheckRequest(request, parser);
   // CheckRequest("5\r\n", parser);
   // CheckRequest("hello\r\n", parser);

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -26,6 +26,7 @@ TEST(HTTPRequestParser, ParseRequestGET) {
   EXPECT_EQ(req.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req.Unwrap()->GetBody(), "");
+  delete req.Unwrap();
 }
 
 // GETリクエストのパース(ヘッダがバラバラに送られてくる場合）
@@ -45,6 +46,7 @@ TEST(HTTPRequestParser, ParseRequestGET_Header_kNotEnough) {
   EXPECT_EQ(req1.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req1.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req1.Unwrap()->GetBody(), "");
+  delete req1.Unwrap();
 }
 
 // requestlineエラーケース
@@ -119,6 +121,7 @@ TEST(HTTPRequestParser, ParseRequestPOST) {
   EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+  delete req2.Unwrap();
 }
 
 // Transfer-Encodingのパース
@@ -146,6 +149,7 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+  delete req2.Unwrap();
 }
 //// Transfer-Encodingのパース 2度の処理がくる場合
 TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked2) {
@@ -160,6 +164,7 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked2) {
   EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+  delete req2.Unwrap();
   request =
       "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
       "chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
@@ -170,6 +175,7 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked2) {
   EXPECT_EQ(req3.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req3.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req3.Unwrap()->GetBody(), "hello");
+  delete req3.Unwrap();
 }
 
 // Transfer-Encodingのエラーケース数字来ないで終わる

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -126,10 +126,13 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "hello\r\n";
   Result<HTTPRequest *, int> req3 = parser.Parser(request);
-  //  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "\r\n";
+  Result<HTTPRequest *, int> req5 = parser.Parser(request);
+  EXPECT_EQ(req5.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "0\r\n";
   Result<HTTPRequest *, int> req4 = parser.Parser(request);
-  //  EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "\r\n";
   Result<HTTPRequest *, int> req2 = parser.Parser(request);
   EXPECT_EQ(req2.Unwrap()->GetMethod(), "POST");

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -7,8 +7,8 @@
 #include "http_request.hpp"
 #include "http_request_parser.hpp"
 
-// kEndHandlerのテスト
-TEST(HTTPRequestParser, kEndHandler) {
+// kEndParseのテスト
+TEST(HTTPRequestParser, kEndParse) {
   std::string request = "";
   HTTPRequestParser parser;
   const Result<HTTPRequest *, int> req = parser.Parser(request);

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -16,7 +16,7 @@ TEST(HTTPRequestParser, ParseRequestGET) {
   EXPECT_EQ(req.Unwrap()->GetUri(), "/");
   EXPECT_EQ(req.Unwrap()->GetProtocol(), "HTTP");
   EXPECT_EQ(req.Unwrap()->GetVersion(), "1.1");
-  EXPECT_EQ(req.Unwrap()->GetHostHeader(), "localhost:8080");
+EXPECT_EQ(req.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req.Unwrap()->GetBody(), "");
 }
 
@@ -35,7 +35,7 @@ TEST(HTTPRequestParser, ParseRequestGET_Header_kNotEnough) {
   EXPECT_EQ(req1.Unwrap()->GetUri(), "/");
   EXPECT_EQ(req1.Unwrap()->GetProtocol(), "HTTP");
   EXPECT_EQ(req1.Unwrap()->GetVersion(), "1.1");
-  EXPECT_EQ(req1.Unwrap()->GetHostHeader(), "localhost:8080");
+  EXPECT_EQ(req1.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req1.Unwrap()->GetBody(), "");
 }
 
@@ -109,6 +109,33 @@ TEST(HTTPRequestParser, ParseRequestPOST) {
   EXPECT_EQ(req2.Unwrap()->GetUri(), "/");
   EXPECT_EQ(req2.Unwrap()->GetProtocol(), "HTTP");
   EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
-  EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "localhost:8080");
+  EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
+  EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+}
+
+// POSTリクエストのパース
+TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n";
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "5\r\n";
+  Result<HTTPRequest *, int> req1 = parser.Parser(request);
+  EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "hello\r\n";
+  Result<HTTPRequest *, int> req3 = parser.Parser(request);
+  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "0\r\n";
+  Result<HTTPRequest *, int> req4 = parser.Parser(request);
+  EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "\r\n";
+  Result<HTTPRequest *, int> req2 = parser.Parser(request);
+  EXPECT_EQ(req2.Unwrap()->GetMethod(), "POST");
+  EXPECT_EQ(req2.Unwrap()->GetUri(), "/");
+  EXPECT_EQ(req2.Unwrap()->GetProtocol(), "HTTP");
+  EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
+  EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
 }

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -113,7 +113,7 @@ TEST(HTTPRequestParser, ParseRequestPOST) {
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
 }
 
-// POSTリクエストのパース
+// Transfer-Encodingのパース
 TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   HTTPRequestParser parser;
   std::string request =
@@ -141,4 +141,95 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+}
+//// Transfer-Encodingのパース 2度の処理がくる場合
+TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked2) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n5\r\nhello\r\n\r\n0\r\n\r\n";
+  Result<HTTPRequest *, int> req2 = parser.Parser(request);
+  EXPECT_EQ(req2.Unwrap()->GetMethod(), "POST");
+  EXPECT_EQ(req2.Unwrap()->GetUri(), "/");
+  EXPECT_EQ(req2.Unwrap()->GetProtocol(), "HTTP");
+  EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
+  EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
+  EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+  request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n5\r\nhello\r\n\r\n0\r\n\r\n";
+  Result<HTTPRequest *, int> req3 = parser.Parser(request);
+  EXPECT_EQ(req3.Unwrap()->GetMethod(), "POST");
+  EXPECT_EQ(req3.Unwrap()->GetUri(), "/");
+  EXPECT_EQ(req3.Unwrap()->GetProtocol(), "HTTP");
+  EXPECT_EQ(req3.Unwrap()->GetVersion(), "1.1");
+  EXPECT_EQ(req3.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
+  EXPECT_EQ(req3.Unwrap()->GetBody(), "hello");
+}
+
+// Transfer-Encodingのエラーケース数字来ないで終わる
+TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked_Error1) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n";
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "\r\n";
+  Result<HTTPRequest *, int> req1 = parser.Parser(request);
+  EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kBadRequest);
+}
+
+// Transfer-Encodingのエラーケース数字が来ても0\r\nがない
+TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked_Error2) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n";
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "5\r\n";
+  Result<HTTPRequest *, int> req1 = parser.Parser(request);
+  EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "hello\r\n";
+  Result<HTTPRequest *, int> req3 = parser.Parser(request);
+  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "\r\n\r\n";
+  Result<HTTPRequest *, int> req5 = parser.Parser(request);
+  EXPECT_EQ(req5.UnwrapErr(), HTTPRequestParser::kBadRequest);
+}
+
+// Transfer-Encodingのエラーケース: チャンクの文字数が多い
+TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked_Error3) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n";
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "5\r\n";
+  Result<HTTPRequest *, int> req1 = parser.Parser(request);
+  EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "hello\r\n";
+  Result<HTTPRequest *, int> req3 = parser.Parser(request);
+  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "0\r\naaaaaa\r\n";
+  Result<HTTPRequest *, int> req5 = parser.Parser(request);
+  EXPECT_EQ(req5.UnwrapErr(), HTTPRequestParser::kBadRequest);
+}
+
+// Transfer-Encodingのエラーケース: チャンクの文字数が少ない
+TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked_Error4) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n";
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "5\r\n";
+  Result<HTTPRequest *, int> req1 = parser.Parser(request);
+  EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "hel\r\n";
+  Result<HTTPRequest *, int> req3 = parser.Parser(request);
+  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kBadRequest);
 }

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -7,6 +7,14 @@
 #include "http_request.hpp"
 #include "http_request_parser.hpp"
 
+// kEndHeaderのテスト
+TEST(HTTPRequestParser, kEndHandler) {
+  std::string request = "";
+  HTTPRequestParser parser;
+  const Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kEndParse);
+}
+
 // GETリクエストのパース
 TEST(HTTPRequestParser, ParseRequestGET) {
   std::string request = "GET / HTTP/1.1\r\nHost: localhost:8080\r\n\r\n";

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -7,7 +7,7 @@
 #include "http_request.hpp"
 #include "http_request_parser.hpp"
 
-// kEndHeaderのテスト
+// kEndHandlerのテスト
 TEST(HTTPRequestParser, kEndHandler) {
   std::string request = "";
   HTTPRequestParser parser;

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -127,9 +127,6 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   request = "hello\r\n";
   Result<HTTPRequest *, int> req3 = parser.Parser(request);
   EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
-  request = "\r\n";
-  Result<HTTPRequest *, int> req5 = parser.Parser(request);
-  EXPECT_EQ(req5.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "0\r\n";
   Result<HTTPRequest *, int> req4 = parser.Parser(request);
   EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kNotEnough);
@@ -147,7 +144,7 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked2) {
   HTTPRequestParser parser;
   std::string request =
       "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
-      "chunked\r\n\r\n5\r\nhello\r\n\r\n0\r\n\r\n";
+      "chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
   Result<HTTPRequest *, int> req2 = parser.Parser(request);
   EXPECT_EQ(req2.Unwrap()->GetMethod(), "POST");
   EXPECT_EQ(req2.Unwrap()->GetUri(), "/");
@@ -157,7 +154,7 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked2) {
   EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
   request =
       "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
-      "chunked\r\n\r\n5\r\nhello\r\n\r\n0\r\n\r\n";
+      "chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n";
   Result<HTTPRequest *, int> req3 = parser.Parser(request);
   EXPECT_EQ(req3.Unwrap()->GetMethod(), "POST");
   EXPECT_EQ(req3.Unwrap()->GetUri(), "/");

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -16,7 +16,7 @@ TEST(HTTPRequestParser, ParseRequestGET) {
   EXPECT_EQ(req.Unwrap()->GetUri(), "/");
   EXPECT_EQ(req.Unwrap()->GetProtocol(), "HTTP");
   EXPECT_EQ(req.Unwrap()->GetVersion(), "1.1");
-EXPECT_EQ(req.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
+  EXPECT_EQ(req.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
   EXPECT_EQ(req.Unwrap()->GetBody(), "");
 }
 

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -126,10 +126,10 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "hello\r\n";
   Result<HTTPRequest *, int> req3 = parser.Parser(request);
-  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  //  EXPECT_EQ(req3.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "0\r\n";
   Result<HTTPRequest *, int> req4 = parser.Parser(request);
-  EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  //  EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kNotEnough);
   request = "\r\n";
   Result<HTTPRequest *, int> req2 = parser.Parser(request);
   EXPECT_EQ(req2.Unwrap()->GetMethod(), "POST");


### PR DESCRIPTION
## 1. issue number
#137 

## 2. やったこと
- bodyのset方法を追記できるように変更 src/http/http_request.cpp src/http/http_request.hpp
- transfer-encodingの実装
- 文字列が渡されなかった場合の時用に、kEndHeaderの実装
- header大文字になってなかったので、変更

## 3. やらないこと
## 4. 動作確認
## 5. 懸念点
## 6. 最近楽しかったこと
- よく寝た
## 7. その他
- pushした時にbuildのテストで失敗してたんだけど、原因はメモリリークでした。
- ちょっと１プルリクの内容が多めになってしまったので、次からもっと減らす方向で