### PR TITLE
Headerのvalueに余計な空白があった時の処理 

### DIFF
--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -17,8 +17,9 @@ Result<int, std::string> StrToI(const std::string &str) {
 }
 
 std::string SkipSpace(std::string s) {
-  size_t pos = s.find_first_not_of(" ");
-  s = s.substr(pos);
-  return s;
+  const std::string whitespace = " \t\f\v\n\r";
+  size_t pos_first = s.find_first_not_of(whitespace);
+  size_t pos_last = s.find_last_not_of(whitespace);
+  return s.substr(pos_first, pos_last - pos_first + 1);
 }
 }  // namespace string_utils

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -7,9 +7,9 @@
 #include "http_request.hpp"
 #include "http_request_parser.hpp"
 
-// GETリクエストのパース
+// GETリクエストのパース(余計なスペースがある場合)
 TEST(HTTPRequestParser, ParseRequestGET) {
-  std::string request = "GET / HTTP/1.1\r\nHost: localhost:8080\r\n\r\n";
+  std::string request = "GET / HTTP/1.1\r\nHost: localhost:8080    \r\n\r\n";
   HTTPRequestParser parser;
   const Result<HTTPRequest *, int> req = parser.Parser(request);
   EXPECT_EQ(req.Unwrap()->GetMethod(), "GET");


### PR DESCRIPTION
## 1. issue number
Headerのvalueの値に余計な空白があった時の処理 #140
#154

## 2. やったこと
value側に余計な" \t\f\v\n\r"があった時にそれをvalueに含めない

## 3. やらないこと
## 4. 動作確認  
## 5. 懸念点
## 6. 最近楽しかったこと
## 7. その他
