### PR TITLE
fix #171 contentlength以上の文字列が来た文字列が次の処理に回せるように変更

### DIFF
--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -131,21 +131,18 @@ int HTTPRequestParser::SetRequestHeaders() {
 // bodyのパース
 int HTTPRequestParser::SetRequestBody() {
   std::string request_line = row_line_;
-  size_t pos = 0;
-
   // content-length
   if (request_->GetHeaders().count("CONTENT-LENGTH") > 0) {
-    pos = request_line.find("\r\n");
-    if (pos == std::string::npos) pos = request_line.length();
+    // content-lengthの値を取得
     std::string length = request_->GetHeaders().find("CONTENT-LENGTH")->second;
     Result<int, std::string> result = string_utils::StrToI(length);
     if (result.IsErr()) return kBadRequest;
-    if (static_cast<int>(request_line.length()) < result.Unwrap())
-      return kNotEnough;
-    else {
-      row_line_ = request_line.substr(pos);
-      request_->AddBody(request_line.substr(0, pos));
-    }
+    // request_lineを取得して、長さの確認
+    int pos = static_cast<int>(request_line.length());
+    if (pos < result.Unwrap()) return kNotEnough;
+    if (result.Unwrap() < pos) pos = result.Unwrap();
+    row_line_ = request_line.substr(pos);
+    request_->AddBody(request_line.substr(0, pos));
   }
   // trasfer-encoding
   else {

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -124,6 +124,39 @@ TEST(HTTPRequestParser, ParseRequestPOST) {
   delete req2.Unwrap();
 }
 
+// POSTで次のリクエストもきてた時のパース
+TEST(HTTPRequestParser, ParseRequestPOST_Contentlength_twice) {
+  HTTPRequestParser parser;
+  std::string request =
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: 5\r\n\r\n";
+  Result<HTTPRequest *, int> req = parser.Parser(request);
+  EXPECT_EQ(req.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request = "he";
+  Result<HTTPRequest *, int> req1 = parser.Parser(request);
+  EXPECT_EQ(req1.UnwrapErr(), HTTPRequestParser::kNotEnough);
+  request =
+      "lloPOST / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: "
+      "5\r\n\r\nhello";
+  Result<HTTPRequest *, int> req2 = parser.Parser(request);
+  EXPECT_EQ(req2.Unwrap()->GetMethod(), "POST");
+  EXPECT_EQ(req2.Unwrap()->GetUri(), "/");
+  EXPECT_EQ(req2.Unwrap()->GetProtocol(), "HTTP");
+  EXPECT_EQ(req2.Unwrap()->GetVersion(), "1.1");
+  EXPECT_EQ(req2.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
+  EXPECT_EQ(req2.Unwrap()->GetBody(), "hello");
+  delete req2.Unwrap();
+  Result<HTTPRequest *, int> req3 = parser.Parser(request);
+  EXPECT_EQ(req3.Unwrap()->GetMethod(), "POST");
+  EXPECT_EQ(req3.Unwrap()->GetUri(), "/");
+  EXPECT_EQ(req3.Unwrap()->GetProtocol(), "HTTP");
+  EXPECT_EQ(req3.Unwrap()->GetVersion(), "1.1");
+  EXPECT_EQ(req3.Unwrap()->GetHostHeader(), "LOCALHOST:8080");
+  EXPECT_EQ(req3.Unwrap()->GetBody(), "hello");
+  delete req3.Unwrap();
+  request = "";
+  Result<HTTPRequest *, int> req4 = parser.Parser(request);
+  EXPECT_EQ(req4.UnwrapErr(), HTTPRequestParser::kEndParse);
+}
 // Transfer-Encodingのパース
 TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked) {
   HTTPRequestParser parser;


### PR DESCRIPTION
## 1. issue number
#171 
#170 

## 2. やったこと
content-length以上の文字列が来たときに、次の処理としてrowline_に保存しておく
## 3. やらないこと
## 4. 動作確認
## 5. 懸念点
## 6. 最近楽しかったこと
- メガネの歪み直した。
## 7. その他