### PR TITLE
1pollにつき1writeか1readにした

### DIFF
--- a/src/server/io_task.hpp
+++ b/src/server/io_task.hpp
@@ -7,7 +7,7 @@
 
 class AIOTask {
  public:
-  enum IOTaskStatus { kOk, kTaskDelete, kFdDelete };
+  enum IOTaskStatus { kOk, kContinue, kTaskDelete, kFdDelete };
   AIOTask();
   AIOTask(int fd, int event);
   virtual ~AIOTask();

--- a/src/server/io_task_manager.cpp
+++ b/src/server/io_task_manager.cpp
@@ -1,32 +1,33 @@
 #include "io_task_manager.hpp"
 
-std::vector<std::vector<AIOTask *> > IOTaskManager::tasks_;
+std::vector<Tasks> IOTaskManager::tasks_array_;
 std::vector<struct pollfd> IOTaskManager::fds_;
 
 IOTaskManager::IOTaskManager() {}
 
 IOTaskManager::~IOTaskManager() {
-  for (unsigned int i = 0; i < tasks_.size(); ++i) {
-    for (unsigned int j = 0; j < tasks_.at(i).size(); ++j) {
-      delete tasks_.at(i).at(j);
+  for (unsigned int i = 0; i < tasks_array_.size(); ++i) {
+    for (unsigned int j = 0; j < tasks_array_.at(i).tasks.size(); ++j) {
+      delete tasks_array_.at(i).tasks.at(j);
     }
   }
 }
 
-const std::vector<std::vector<AIOTask *> > &IOTaskManager::GetTasks() {
-  return tasks_;
+const std::vector<Tasks> &IOTaskManager::GetTasks() {
+  return tasks_array_;
 }
 const std::vector<struct pollfd> &IOTaskManager::GetFds() { return fds_; }
 
 void IOTaskManager::AddTask(AIOTask *task) {
   for (unsigned int i = 0; i < fds_.size(); ++i) {
     if (fds_.at(i).fd == task->GetFd()) {
-      std::vector<AIOTask *>::iterator it =
-          std::find(tasks_.at(i).begin(), tasks_.at(i).end(), (AIOTask *)NULL);
-      if (it != tasks_.at(i).end())
-        *it = task;
-      else
-        tasks_.at(i).push_back(task);
+      for (unsigned int j = 0; j < tasks_array_.at(i).tasks.size(); ++j) {
+        if (tasks_array_.at(i).tasks.at(j) == NULL) {
+          tasks_array_.at(i).tasks.at(j) = task;
+          return;
+        }
+      }
+      tasks_array_.at(i).tasks.push_back(task);
       return;
     }
   }
@@ -34,24 +35,24 @@ void IOTaskManager::AddTask(AIOTask *task) {
   for (unsigned int i = 0; i < fds_.size(); ++i) {
     if (fds_.at(i).fd == -1) {
       fds_.at(i) = fd;
-      tasks_.at(i).push_back(task);
+      tasks_array_.at(i).tasks.push_back(task);
       return;
     }
   }
-  std::vector<AIOTask *> tmp;
-  tmp.push_back(task);
-  tasks_.push_back(tmp);
+  Tasks tmp = {std::vector<AIOTask *>(1, task), 0};
+  tasks_array_.push_back(tmp);
   fds_.push_back(fd);
 }
 
 void IOTaskManager::RemoveFd(AIOTask *task) {
   for (unsigned int i = 0; i < fds_.size(); ++i) {
     if (fds_.at(i).fd == task->GetFd()) {
-      for (unsigned int j = 0; j < tasks_.at(i).size(); ++j) {
-        delete tasks_.at(i).at(j);
+      for (unsigned int j = 0; j < tasks_array_.at(i).tasks.size(); ++j) {
+        delete tasks_array_.at(i).tasks.at(j);
       }
       close(fds_.at(i).fd);
-      tasks_.at(i).clear();
+      tasks_array_.at(i).tasks.clear();
+      tasks_array_.at(i).index = 0;
       fds_.at(i).fd = -1;
       Logger::Info() << "接続を削除しました" << std::endl;
       return;
@@ -60,26 +61,13 @@ void IOTaskManager::RemoveFd(AIOTask *task) {
 }
 
 void IOTaskManager::DeleteTasks() {
-  for (unsigned int i = 0; i < tasks_.size(); i++) {
-    for (unsigned int j = 0; j < tasks_.at(i).size(); j++) {
-      if (tasks_.at(i).at(j) != NULL) delete tasks_.at(i).at(j);
+  for (unsigned int i = 0; i < tasks_array_.size(); i++) {
+    for (unsigned int j = 0; j < tasks_array_.at(i).tasks.size(); j++) {
+      delete tasks_array_.at(i).tasks.at(j);
     }
   }
-  tasks_.clear();
+  tasks_array_.clear();
   fds_.clear();
-}
-
-void IOTaskManager::RemoveTask(AIOTask *task) {
-  WriteResponseToClient *tmp = dynamic_cast<WriteResponseToClient *>(task);
-  if (!tmp) return;
-  for (unsigned int i = 0; i < fds_.size(); ++i) {
-    if (fds_.at(i).fd == task->GetFd()) {
-      *(std::find(tasks_.at(i).begin(), tasks_.at(i).end(), task)) = NULL;
-      delete task;
-      Logger::Info() << "ライトタスクを削除しました" << std::endl;
-      return;
-    }
-  }
 }
 
 void IOTaskManager::ExecuteTasks() {
@@ -91,21 +79,26 @@ void IOTaskManager::ExecuteTasks() {
     }
     for (unsigned int i = 0; i < fds_.size(); ++i) {
       if (fds_.at(i).fd == -1) continue;
-      for (unsigned int j = 0; j < tasks_.at(i).size(); ++j) {
-        if (tasks_.at(i).at(j) == NULL) continue;
-        if (fds_.at(i).revents & tasks_.at(i).at(j)->GetEvent()) {
-          Result<int, std::string> result = tasks_.at(i).at(j)->Execute();
+      Tasks &fd_tasks = tasks_array_.at(i);
+      do {
+        fd_tasks.index++;
+        if (fd_tasks.index >= fd_tasks.tasks.size()) {
+          fd_tasks.index = 0;
+          break;
+        }
+      } while (fd_tasks.tasks.at(fd_tasks.index) == NULL || !(fd_tasks.tasks.at(fd_tasks.index)->GetEvent() & fds_.at(i).revents));
+      if (fd_tasks.tasks.at(fd_tasks.index) != NULL && (fd_tasks.tasks.at(fd_tasks.index)->GetEvent() & fds_.at(i).revents)){
+        Result<int, std::string> result = fd_tasks.tasks.at(fd_tasks.index)->Execute();
           if (result.IsErr()) {
             DeleteTasks();
             throw std::invalid_argument("taskエラー");
           } else if (result.Unwrap() == AIOTask::kTaskDelete) {
-            RemoveTask(tasks_.at(i).at(j));
-            --j;
+            delete fd_tasks.tasks.at(fd_tasks.index);
+            fd_tasks.tasks.at(fd_tasks.index) = NULL;
           } else if (result.Unwrap() == AIOTask::kFdDelete) {
-            RemoveFd(tasks_.at(i).at(j));
+            RemoveFd(fd_tasks.tasks.at(fd_tasks.index));
             --i;
           }
-        }
       }
     }
   }

--- a/src/server/io_task_manager.cpp
+++ b/src/server/io_task_manager.cpp
@@ -13,9 +13,7 @@ IOTaskManager::~IOTaskManager() {
   }
 }
 
-const std::vector<Tasks> &IOTaskManager::GetTasks() {
-  return tasks_array_;
-}
+const std::vector<Tasks> &IOTaskManager::GetTasks() { return tasks_array_; }
 const std::vector<struct pollfd> &IOTaskManager::GetFds() { return fds_; }
 
 void IOTaskManager::AddTask(AIOTask *task) {
@@ -86,19 +84,24 @@ void IOTaskManager::ExecuteTasks() {
           fd_tasks.index = 0;
           break;
         }
-      } while (fd_tasks.tasks.at(fd_tasks.index) == NULL || !(fd_tasks.tasks.at(fd_tasks.index)->GetEvent() & fds_.at(i).revents));
-      if (fd_tasks.tasks.at(fd_tasks.index) != NULL && (fd_tasks.tasks.at(fd_tasks.index)->GetEvent() & fds_.at(i).revents)){
-        Result<int, std::string> result = fd_tasks.tasks.at(fd_tasks.index)->Execute();
-          if (result.IsErr()) {
-            DeleteTasks();
-            throw std::invalid_argument("taskエラー");
-          } else if (result.Unwrap() == AIOTask::kTaskDelete) {
-            delete fd_tasks.tasks.at(fd_tasks.index);
-            fd_tasks.tasks.at(fd_tasks.index) = NULL;
-          } else if (result.Unwrap() == AIOTask::kFdDelete) {
-            RemoveFd(fd_tasks.tasks.at(fd_tasks.index));
-            --i;
-          }
+      } while (fd_tasks.tasks.at(fd_tasks.index) == NULL ||
+               !(fd_tasks.tasks.at(fd_tasks.index)->GetEvent() &
+                 fds_.at(i).revents));
+      if (fd_tasks.tasks.at(fd_tasks.index) != NULL &&
+          (fd_tasks.tasks.at(fd_tasks.index)->GetEvent() &
+           fds_.at(i).revents)) {
+        Result<int, std::string> result =
+            fd_tasks.tasks.at(fd_tasks.index)->Execute();
+        if (result.IsErr()) {
+          DeleteTasks();
+          throw std::invalid_argument("taskエラー");
+        } else if (result.Unwrap() == AIOTask::kTaskDelete) {
+          delete fd_tasks.tasks.at(fd_tasks.index);
+          fd_tasks.tasks.at(fd_tasks.index) = NULL;
+        } else if (result.Unwrap() == AIOTask::kFdDelete) {
+          RemoveFd(fd_tasks.tasks.at(fd_tasks.index));
+          --i;
+        }
       }
     }
   }

--- a/src/server/io_task_manager.cpp
+++ b/src/server/io_task_manager.cpp
@@ -81,7 +81,7 @@ void IOTaskManager::ExecuteTasks() {
       while (fd_tasks.tasks.at(fd_tasks.index) == NULL ||
              !(fd_tasks.tasks.at(fd_tasks.index)->GetEvent() &
                fds_.at(i).revents)) {
-        fd_tasks.index++;
+        ++(fd_tasks.index);
         if (fd_tasks.index >= fd_tasks.tasks.size()) {
           fd_tasks.index = 0;
           break;
@@ -104,7 +104,7 @@ void IOTaskManager::ExecuteTasks() {
         } else if (result.Unwrap() == AIOTask::kContinue) {
           ;
         } else if (result.Unwrap() == AIOTask::kOk) {
-          fd_tasks.index++;
+          ++(fd_tasks.index);
         }
       }
     }

--- a/src/server/io_task_manager.cpp
+++ b/src/server/io_task_manager.cpp
@@ -78,6 +78,7 @@ void IOTaskManager::ExecuteTasks() {
     for (unsigned int i = 0; i < fds_.size(); ++i) {
       if (fds_.at(i).fd == -1) continue;
       struct Tasks &fd_tasks = tasks_array_.at(i);
+      fd_tasks.index >= fd_tasks.tasks.size() ? fd_tasks.index = 0 : 0;
       while (fd_tasks.tasks.at(fd_tasks.index) == NULL ||
              !(fd_tasks.tasks.at(fd_tasks.index)->GetEvent() &
                fds_.at(i).revents)) {

--- a/src/server/io_task_manager.hpp
+++ b/src/server/io_task_manager.hpp
@@ -11,6 +11,11 @@
 #include "read_request_from_client.hpp"
 #include "write_response_to_client.hpp"
 
+struct Tasks {
+  std::vector<AIOTask *> tasks;
+  unsigned int index;
+};
+
 class IOTaskManager {
  public:
   ~IOTaskManager();
@@ -19,17 +24,16 @@ class IOTaskManager {
   static void RemoveTask(AIOTask *task);
   static void DeleteTasks();
   static void ExecuteTasks();
-  static const std::vector<std::vector<AIOTask *> > &GetTasks();
+  static const std::vector<Tasks> &GetTasks();
   static const std::vector<struct pollfd> &GetFds();
 
  private:
   IOTaskManager();
   IOTaskManager(const IOTaskManager &other);
   IOTaskManager &operator=(const IOTaskManager &other);
-  static std::vector<std::vector<AIOTask *> > tasks_;
+  static std::vector<Tasks> tasks_array_;
   static std::vector<struct pollfd> fds_;
   static const int poll_time_out_ = 5000;
-  enum Error { kOk, kDelete };
 };
 
 #endif

--- a/src/server/write_response_to_client.cpp
+++ b/src/server/write_response_to_client.cpp
@@ -14,5 +14,5 @@ Result<int, std::string> WriteResponseToClient::Execute() {
       write(fd_, response_str.c_str(), response_str.size());
   if ((wrote_size_ += bytes_written) == response_str.size())
     return Ok(kTaskDelete);
-  return Ok(0);
+  return Ok(kContinue);
 }

--- a/test/io_task_manager_test.cpp
+++ b/test/io_task_manager_test.cpp
@@ -15,14 +15,14 @@ TEST(IOTaskManager, DefaultTest) {
   WriteResponseToClient *res = new WriteResponseToClient(4, new HTTPResponse);
   IOTaskManager::AddTask(res);
   ASSERT_EQ(2, IOTaskManager::GetTasks().size());
-  ASSERT_EQ(2, IOTaskManager::GetTasks().at(1).size());
+  ASSERT_EQ(2, IOTaskManager::GetTasks().at(1).tasks.size());
   ASSERT_EQ(2, IOTaskManager::GetFds().size());
   IOTaskManager::RemoveFd(req);
   ASSERT_EQ(2, IOTaskManager::GetTasks().size());
   ASSERT_EQ(2, IOTaskManager::GetFds().size());
   // ASSERT_EQ(0, IOTaskManager::GetTasks().at(0).size());
   ASSERT_EQ(-1, IOTaskManager::GetFds().at(1).fd);
-  ASSERT_EQ(0, IOTaskManager::GetTasks().at(1).size());
+  ASSERT_EQ(0, IOTaskManager::GetTasks().at(1).tasks.size());
   req = new ReadRequestFromClient(5, "8080", "", conf);
   IOTaskManager::AddTask(req);
   ASSERT_EQ(2, IOTaskManager::GetTasks().size());
@@ -30,7 +30,7 @@ TEST(IOTaskManager, DefaultTest) {
   res = new WriteResponseToClient(5, new HTTPResponse);
   IOTaskManager::AddTask(res);
   ASSERT_EQ(2, IOTaskManager::GetTasks().size());
-  ASSERT_EQ(2, IOTaskManager::GetTasks().at(1).size());
+  ASSERT_EQ(2, IOTaskManager::GetTasks().at(1).tasks.size());
   ASSERT_EQ(2, IOTaskManager::GetFds().size());
   ASSERT_EQ(5, IOTaskManager::GetFds().at(1).fd);
   IOTaskManager::DeleteTasks();


### PR DESCRIPTION
## 1. issue number
#149 

## 2. やったこと
1pollにつき1fd 1taskにした
taskの配列にindexを持たせて、順番に見ていく仕様になっている
writeresponseが終了しなかったときは次もそのタスクを優先的に行う
## 3. やらないこと


## 4. 動作確認
#185 で１０万文字入力、cgiからの出力１０万文字くらいなら動いた
１００万だとバグるから、そのえら飯が必要そう
  
## 5. 懸念点
これだと一気にレスポンス送れなかった時にレスポンスが混ざりそう。
writeresponseが終了しなかったときは次もそのタスクを優先的に行う訂正をした
## 6. 最近楽しかったこと


## 7. その他
