### PR TITLE
URIの上限を設定

### DIFF
--- a/src/http/request_handler.cpp
+++ b/src/http/request_handler.cpp
@@ -15,10 +15,19 @@ HTTPResponse *RequestHandler::Handle(const IConfig &config,
         .SetStatusCode(http::kInternalServerError)
         .Build();
   }
-  (void)config;
-  (void)port;
-  (void)ip;
-  return new HTTPResponse();
+  if (request->GetUri().length() >= kMaxUriLength) {
+    return GenerateErrorResponse(http::kUriTooLong, config);
+  }
+  if (request->GetMethod() == "GET") {
+    return Get(config, request, port, ip);
+  }
+  if (request->GetMethod() == "POST") {
+    return Post(config, request, port, ip);
+  }
+  if (request->GetMethod() == "DELETE") {
+    return Delete(config, request, port, ip);
+  }
+  return GenerateErrorResponse(http::kNotImplemented, config);
 }
 
 HTTPResponse *RequestHandler::Get(const IConfig &config,

--- a/src/http/request_handler.hpp
+++ b/src/http/request_handler.hpp
@@ -21,6 +21,8 @@ class RequestHandler {
   RequestHandler(const RequestHandler &other);
   RequestHandler &operator=(const RequestHandler &other);
   ~RequestHandler();
+
+  static const int kMaxUriLength = 2048;
 };
 
 #endif  // WEBSERV_SRC_HTTP_REQUEST_HANDLER_HPP_


### PR DESCRIPTION
## 1. issue number
#205 

## 2. やったこと
uriの上限を2048にした。
chromeとかedgeがブラウザのなかでは短めの2000ちょいまで対応してるからそれに合わせました。

## 3. やらないこと


## 4. 動作確認

  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
