### PR TITLE
feat : 空白が複数ある場合を許容する

### DIFF
--- a/src/http/a_parser.cpp
+++ b/src/http/a_parser.cpp
@@ -29,6 +29,7 @@ int AParser::SetRequestLine() {
   request_->SetMethod(StrToUpper(result.first));
 
   // uri
+  request_line = string_utils::SkipSpace(request_line);
   result = ParsePart(request_line, " ", kBadRequest);
   if (result.second != kOk) return result.second;
   pos = result.first.find("?");
@@ -40,6 +41,7 @@ int AParser::SetRequestLine() {
   }
 
   // protocol
+  request_line = string_utils::SkipSpace(request_line);
   result = ParsePart(request_line, "/", kBadRequest);
   if (result.second != kOk) return result.second;
   request_->SetProtocol(StrToUpper(result.first));

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -17,12 +17,14 @@ TEST(HTTPRequestParser, kEndParse) {
 
 // GETリクエストのパース(ちょっと特殊なタイプ）
 TEST(HTTPRequestParser, ParseRequestGET) {
-  // valueの後ろに無駄に空白とか
-  std::string request = "GET / HTTP/1.1\r\nHost: localhost:8080    \r\n\r\n";
+  // 無駄にいろんなところに空白
+  std::string request =
+      "GET  /a?b    HTTP/1.1    \r\nHost: localhost:8080    \r\n\r\n";
   HTTPRequestParser parser;
   const Result<HTTPRequest *, int> req = parser.Parser(request);
   EXPECT_EQ(req.Unwrap()->GetMethod(), "GET");
-  EXPECT_EQ(req.Unwrap()->GetUri(), "/");
+  EXPECT_EQ(req.Unwrap()->GetUri(), "/a");
+  EXPECT_EQ(req.Unwrap()->GetQuery(), "b");
   EXPECT_EQ(req.Unwrap()->GetProtocol(), "HTTP");
   EXPECT_EQ(req.Unwrap()->GetVersion(), "1.1");
   EXPECT_EQ(req.Unwrap()->GetHostHeader(), "localhost:8080");


### PR DESCRIPTION
## 1. issue number
#241

## 2. やったこと
```
GET       /index.html       HTTP/1.1
```
こんな形式の空白がたくさんあるリクエストラインを読めるようにした。

## 3. やらないこと
## 4. 動作確認
## 5. 懸念点
## 6. 最近楽しかったこと
渋谷から42まで歩いた。楽しかった。
## 7. その他