### PR TITLE
233 transfer encoding always chunked body

### DIFF
--- a/src/http/a_parser.cpp
+++ b/src/http/a_parser.cpp
@@ -216,10 +216,7 @@ int AParser::BadChunkedBody(int &chunked_state, size_t &chunked_size) {
 }
 
 bool AParser::IsChunked() {
-  if ((request_->GetHeaders().count("TRANSFER-ENCODING") > 0) &&
-      (StrToUpper(request_->GetHeaders().find("TRANSFER-ENCODING")->second) ==
-       "CHUNKED"))
-    return true;
+  if (request_->GetHeaders().count("TRANSFER-ENCODING") > 0) return true;
   return false;
 }
 

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -52,7 +52,7 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
 int HTTPRequestParser::SetHeader() {
   std::string request_line;
   std::string headline, key, value;
-  size_t pos, key_pos = 0;
+  size_t pos = 0, key_pos = 0;
 
   while (1) {
     pos = row_line_.find("\r\n");

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -50,37 +50,24 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
 }
 
 int HTTPRequestParser::SetHeader() {
-  std::string request_line = row_line_;
+  std::string request_line;
   std::string headline, key, value;
-  size_t pos = 0;
-  size_t key_pos = 0;
-  size_t value_pos = 0;
+  size_t pos, key_pos = 0;
 
   while (1) {
+    pos = row_line_.find("\r\n");
+    if (pos == std::string::npos) return kNotEnough;  // 改行がない時
+    request_line = row_line_.substr(0, pos);
+    row_line_ = row_line_.substr(pos + 2);
+    if (request_line == "") break;  // Headerの最終の空行の処理
     key_pos = request_line.find(":");
-    if (key_pos == std::string::npos) break;  // 最後まで見てしまった時
-    pos = request_line.find("\r\n");
-    if (pos == std::string::npos) break;    // 改行がない時
-    if (pos < key_pos) return kBadRequest;  // 改行が先にある時
-    if (key_pos == 0) return kBadRequest;   // 左辺が何もない
+    if (key_pos == std::string::npos || key_pos == 0)
+      return kBadRequest;  // :がない、もしくは左辺が何もない
     key = request_line.substr(0, key_pos);
-    if (pos == key_pos + 1) {
-      value_pos = 0;
-      value = "";
-    } else {
-      value_pos = pos - key_pos - 1;
-      value =
-          string_utils::SkipSpace(request_line.substr(key_pos + 1, value_pos));
-    }
+    value = request_line.substr(key_pos + 1);
     if (StrToUpper(key) == "HOST" && request_->GetHeaders().count("HOST") > 0)
-      return kBadRequest;
-    request_line = request_line.substr(key_pos + value_pos + 3);
-    request_->AddHeader(StrToUpper(key), value);
+      return kBadRequest;  // Hostが複数ある時
+    request_->AddHeader(StrToUpper(key), string_utils::SkipSpace(value));
   }
-  // headerの終わりの確認
-  row_line_ = request_line;
-  // まだheaderが続いている場合
-  if (request_line.find("\r\n") != 0) return kNotEnough;
-  row_line_ = request_line.substr(2);
   return kOk;
 }

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -41,6 +41,8 @@ std::string SkipSpace(std::string s) {
   const std::string whitespace = " \t\f\v\n\r";
   size_t pos_first = s.find_first_not_of(whitespace);
   size_t pos_last = s.find_last_not_of(whitespace);
+  if (pos_first == std::string::npos || pos_last == std::string::npos)
+    return "";
   return s.substr(pos_first, pos_last - pos_first + 1);
 }
 }  // namespace string_utils


### PR DESCRIPTION
## 1. issue number
#233
## 2. やったこと
- transfer-encodingがあると必ずchunkedになるようにする
- SkipSpaceがバグっていたので、修正
- テストの追加

## 3. やらないこと
## 4. 動作確認
## 5. 懸念点
## 6. 最近楽しかったこと
能見てきた。
凄すぎてよくわからなかった。
説明できるだけの古典の知識と語彙力が足りない。
とても良かった。
## 7. その他