### PR TITLE
268 request body が長すぎた時

### DIFF
--- a/src/http/a_parser.cpp
+++ b/src/http/a_parser.cpp
@@ -179,20 +179,12 @@ int AParser::SetBody() {
   return kOk;
 }
 
-const Result<HTTPRequest *, int> AParser::HttpVersionNotSupported() {
+const Result<HTTPRequest *, int> AParser::ErrRequest(int status_code) {
   parser_state_ = kBeforeProcess;
   row_line_ = "";  // 一旦リセット
   delete request_;
   request_ = NULL;
-  return Err(kHttpVersionNotSupported);
-}
-
-const Result<HTTPRequest *, int> AParser::BadRequest() {
-  parser_state_ = kBeforeProcess;
-  row_line_ = "";  // 一旦リセット
-  delete request_;
-  request_ = NULL;
-  return Err(kBadRequest);
+  return Err(status_code);
 }
 
 const Result<HTTPRequest *, int> AParser::OkRequest() {

--- a/src/http/a_parser.cpp
+++ b/src/http/a_parser.cpp
@@ -122,6 +122,7 @@ int AParser::SetRequestBody() {
     std::string length = request_->GetHeaders().find("CONTENT-LENGTH")->second;
     Result<int, std::string> result = string_utils::StrToI(length);
     if (result.IsErr()) return kBadRequest;
+    if (kMaxBodySize < result.Unwrap()) return kPayloadTooLarge;
     // request_lineを取得して、長さの確認
     int pos = static_cast<int>(request_line.length());
     if (pos < result.Unwrap()) return kNotEnough;

--- a/src/http/a_parser.hpp
+++ b/src/http/a_parser.hpp
@@ -31,8 +31,8 @@ class AParser {
   enum chunked_state {
     kNeedChunkedSize,
     kNeedChunkedBody,
+	kMaxBodySize = 100000000
   };
-  kMaxBodySize = 100000000;
   HTTPRequest *request_;
   std::string row_line_;
   int parser_state_;
@@ -60,9 +60,8 @@ class AParser {
   int BadChunkedBody(int &chunked_state, size_t &chunked_size);
   int SetBody();
 
-  const Result<HTTPRequest *, int> HttpVersionNotSupported();
-  const Result<HTTPRequest *, int> BadRequest();
   const Result<HTTPRequest *, int> OkRequest();
+  const Result<HTTPRequest *, int> ErrRequest(int status_code);
 };
 
 #endif  // WEBSERVE_SRC_HTTP_A_PARSER_HPP

--- a/src/http/a_parser.hpp
+++ b/src/http/a_parser.hpp
@@ -9,6 +9,7 @@
 #include "http_status_code.hpp"
 #include "result.hpp"
 #include "string_utils.hpp"
+#include "validation.hpp"
 
 class AParser {
  public:

--- a/src/http/a_parser.hpp
+++ b/src/http/a_parser.hpp
@@ -29,7 +29,7 @@ class AParser {
 
  protected:
   enum StatusFlag { kBeforeProcess, kNeedHeader, kEndHeader, kNeedBody };
-  enum chunked_state {
+  enum ChunkedStateFlag {
     kNeedChunkedSize,
     kNeedChunkedBody,
     kMaxBodySize = 100000000

--- a/src/http/a_parser.hpp
+++ b/src/http/a_parser.hpp
@@ -31,7 +31,7 @@ class AParser {
   enum chunked_state {
     kNeedChunkedSize,
     kNeedChunkedBody,
-	kMaxBodySize = 100000000
+    kMaxBodySize = 100000000
   };
   HTTPRequest *request_;
   std::string row_line_;

--- a/src/http/a_parser.hpp
+++ b/src/http/a_parser.hpp
@@ -33,6 +33,11 @@ class AParser {
     kNeedChunkedBody,
     kMaxBodySize = 100000000
   };
+  struct ChunkedState {
+    int chunked_state;
+    size_t chunked_size;
+    size_t total_size;
+  };
   HTTPRequest *request_;
   std::string row_line_;
   int parser_state_;
@@ -57,7 +62,7 @@ class AParser {
   int CheckHeader();
   int SetRequestBody();
   int SetChunkedBody();
-  int BadChunkedBody(int &chunked_state, size_t &chunked_size);
+  int ResetChunkedBody(ChunkedState &state, int status_code);
   int SetBody();
 
   const Result<HTTPRequest *, int> OkRequest();

--- a/src/http/a_parser.hpp
+++ b/src/http/a_parser.hpp
@@ -17,7 +17,8 @@ class AParser {
     kNotEnough = 1,
     kEndParse = 2,
     kBadRequest = http::kBadRequest,
-    kHttpVersionNotSupported = http::kHttpVersionNotSupported
+    kHttpVersionNotSupported = http::kHttpVersionNotSupported,
+    kPayloadTooLarge = http::kPayloadTooLarge
   };
   AParser();
   AParser(const AParser &other);
@@ -31,6 +32,7 @@ class AParser {
     kNeedChunkedSize,
     kNeedChunkedBody,
   };
+  kMaxBodySize = 100000000;
   HTTPRequest *request_;
   std::string row_line_;
   int parser_state_;

--- a/src/http/cgi_parser.cpp
+++ b/src/http/cgi_parser.cpp
@@ -13,8 +13,8 @@ const Result<HTTPRequest *, int> CGIParser::Parser(std::string request_line) {
   int status = SetHeader();
   if (status == kNotEnough)
     return Err(kNotEnough);
-  else if (status == kBadRequest)
-    return BadRequest();
+  else if (status != kOk)
+    return ErrRequest(status);
   // bodyをセット
   SetBody();
   return OkRequest();

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -33,7 +33,7 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
     else if (return_state != kOk)
       return ErrRequest(return_state);
     else {
-    if (CheckNeedBodyHeader() == false) return ErrRequest(kBadRequest);
+      if (CheckNeedBodyHeader() == false) return ErrRequest(kBadRequest);
     }
   }
   // bodyの内容を確認

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -19,23 +19,21 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
   // requestlineの内容を確認
   if (parser_state_ == kBeforeProcess) {
     return_state = SetRequestLine();
-    if (return_state == kBadRequest)
-      return BadRequest();
-    else if (return_state == kNotEnough)
+    if (return_state == kNotEnough)
       return Err(kNotEnough);
-    else if (return_state == kHttpVersionNotSupported)
-      return HttpVersionNotSupported();
+    else if (return_state != kOk)
+      return ErrRequest(return_state);
     parser_state_ = kNeedHeader;
   }
   // Headerの内容を確認
   if (parser_state_ == kNeedHeader) {
     return_state = SetRequestHeaders();
-    if (return_state == kBadRequest)
-      return BadRequest();
-    else if (return_state == kNotEnough)
+    if (return_state == kNotEnough)
       return Err(kNotEnough);
+    else if (return_state != kOk)
+      return ErrRequest(return_state);
     else {
-      if (CheckNeedBodyHeader() == false) return BadRequest();
+    if (CheckNeedBodyHeader() == false) return ErrRequest(kBadRequest);
     }
   }
   // bodyの内容を確認
@@ -43,8 +41,8 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
     return_state = SetRequestBody();
     if (return_state == kNotEnough)
       return Err(kNotEnough);
-    else if (return_state == kBadRequest)
-      return BadRequest();
+    else if (return_state != kOk)
+      return ErrRequest(return_state);
   }
   return OkRequest();
 }

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -383,7 +383,7 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked_Error4) {
   request = "5F5E100\r\n";
   Result<HTTPRequest *, int> req5 = parser.Parser(request);
   EXPECT_EQ(req5.UnwrapErr(), HTTPRequestParser::kPayloadTooLarge);
-  request = 
+  request =
       "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
       "chunked\r\n\r\n0123456789abcdef\r\n";
   Result<HTTPRequest *, int> req6 = parser.Parser(request);

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -110,6 +110,12 @@ TEST(HTTPRequestParser, ParseRequestGET_Requestline_BadRequest) {
       "100000001\r\n\r\n";
   Result<HTTPRequest *, int> req10 = parser.Parser(request);
   EXPECT_EQ(req10.UnwrapErr(), HTTPRequestParser::kPayloadTooLarge);
+  // content-lengthがINTMAX
+  request =
+      "GET / HTTP/1.1\r\nHost: localhost:8080\r\nContent-Length: "
+      "10000000000000000000000000000000000000\r\n\r\n";
+  Result<HTTPRequest *, int> req11 = parser.Parser(request);
+  EXPECT_EQ(req11.UnwrapErr(), HTTPRequestParser::kPayloadTooLarge);
 }
 
 // headerエラーケース
@@ -377,6 +383,11 @@ TEST(HTTPRequestParser, ParseRequestPOST_Transfer_chunked_Error4) {
   request = "5F5E100\r\n";
   Result<HTTPRequest *, int> req5 = parser.Parser(request);
   EXPECT_EQ(req5.UnwrapErr(), HTTPRequestParser::kPayloadTooLarge);
+  request = 
+      "POST / HTTP/1.1\r\nHost: localhost:8080\r\nTransfer-Encoding: "
+      "chunked\r\n\r\n0123456789abcdef\r\n";
+  Result<HTTPRequest *, int> req6 = parser.Parser(request);
+  EXPECT_EQ(req6.UnwrapErr(), HTTPRequestParser::kPayloadTooLarge);
 }
 
 // Transfer-Encodingとcontent-lengthが両方ある場合


### PR DESCRIPTION
## 1. issue number
#268
## 2. やったこと
- conten-tlengthかchunkedの合計が１億以上になったら413を返すように
- INTMAX以上の値でErrが返ってきてたから、413が帰るように
- 上記に伴って、好きな番号をErrとして返せるように仕様変更
- SetChunkedBodyのstaticが増えすぎたので構造体に。
- テストの追加
## 3. やらないこと
## 4. 動作確認  
## 5. 懸念点
## 6. 最近楽しかったこと
## 7. その他
