### PR TITLE
request line を送る前の空行+改行は無視するようにに対応

### DIFF
--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -1,7 +1,5 @@
 #include "http_request_parser.hpp"
 
-#include <unistd.h>
-
 #include "a_parser.hpp"
 
 // canonical
@@ -14,11 +12,11 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
   int return_state;
   row_line_ = row_line_ + request_line;
 
-  // リクエストラインが来るまでの適当改行などは無視するように
+  // リクエストラインが来るまでの適当な改行などは無視するように
   if (parser_state_ == kBeforeProcess &&
-      (row_line_ == "\r\n" || row_line_ == "")) {
-    row_line_ = "";
-    return Err(kEndParse);
+      (row_line_.find("\r\n") == 0 || row_line_ == "")) {
+    while (row_line_.find("\r\n") == 0) row_line_ = row_line_.substr(2);
+    if (row_line_ == "") return Err(kEndParse);
   }
   if (request_ == NULL) request_ = new HTTPRequest();
   // requestlineの内容を確認

--- a/src/http/http_request_parser.cpp
+++ b/src/http/http_request_parser.cpp
@@ -14,7 +14,12 @@ const Result<HTTPRequest *, int> HTTPRequestParser::Parser(
   int return_state;
   row_line_ = row_line_ + request_line;
 
-  if (row_line_ == "") return Err(kEndParse);
+  // リクエストラインが来るまでの適当改行などは無視するように
+  if (parser_state_ == kBeforeProcess &&
+      (row_line_ == "\r\n" || row_line_ == "")) {
+    row_line_ = "";
+    return Err(kEndParse);
+  }
   if (request_ == NULL) request_ = new HTTPRequest();
   // requestlineの内容を確認
   if (parser_state_ == kBeforeProcess) {

--- a/test/request_parser_test.cpp
+++ b/test/request_parser_test.cpp
@@ -46,6 +46,11 @@ TEST(HTTPRequestParser, ParseRequestGET) {
   Result<HTTPRequest *, int> req9 = parser.Parser(request);
   EXPECT_EQ(req9.Unwrap()->GetMethod(), "GET");
   delete req9.Unwrap();
+  // リクエストラインの前に余計な改行がある
+  request = "\r\n\r\nGET / HTTP/1.1\r\nHost:\r\n\r\n";
+  Result<HTTPRequest *, int> req10 = parser.Parser(request);
+  EXPECT_EQ(req10.Unwrap()->GetMethod(), "GET");
+  delete req10.Unwrap();
 }
 
 // GETリクエストのパース(ヘッダがバラバラに送られてくる場合）


### PR DESCRIPTION
## 1. issue number
#306 
## 2. やったこと
feat: リクエストラインを送る前の改行は無視するようにに対応
e.g.
````C
kaaaaakun_@kaaaaakun-noMacBook-Air webserv % telnet localhost 8002
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.






GET / HTTP/1.1
Host:a
````
(やったけど、別にいらんかったかも)

## 3. やらないこと
## 4. 動作確認
## 5. 懸念点
## 6. 最近楽しかったこと
- 里芋茹でたら、美味しかった。
## 7. その他
