### PR TITLE
telnetでEOF(ascii4番)がきたら400を返して終了するように

### DIFF
--- a/src/server/read_request_from_client.cpp
+++ b/src/server/read_request_from_client.cpp
@@ -32,7 +32,7 @@ Result<int, std::string> ReadRequestFromClient::Execute() {
                    << std::endl;
     IOTaskManager::AddTask(new WriteResponseToClient(
         fd_, GenerateErrorResponse(http::kBadRequest, config_),
-        static_cast<HTTPRequest *>(NULL)));
+        new HTTPRequest()));
     return Ok(kOk);
   }
   buf[len] = '\0';

--- a/src/server/read_request_from_client.cpp
+++ b/src/server/read_request_from_client.cpp
@@ -27,7 +27,7 @@ Result<int, std::string> ReadRequestFromClient::Execute() {
                    << std::endl;
     return Ok(kFdDelete);
   }
-  if (len == 1 && buf[0] == static_cast<char>(kEOF)) {
+  if (len == 1 && buf[0] == static_cast<char>(kEOT)) {
     Logger::Info() << ip_ << ":" << port_ << " : 接続が切られました"
                    << std::endl;
     IOTaskManager::AddTask(new WriteResponseToClient(

--- a/src/server/read_request_from_client.cpp
+++ b/src/server/read_request_from_client.cpp
@@ -27,6 +27,14 @@ Result<int, std::string> ReadRequestFromClient::Execute() {
                    << std::endl;
     return Ok(kFdDelete);
   }
+  if (len == 1 && buf[0] == static_cast<char>(kEOF)) {
+    Logger::Info() << ip_ << ":" << port_ << " : 接続が切られました"
+                   << std::endl;
+    IOTaskManager::AddTask(new WriteResponseToClient(
+        fd_, GenerateErrorResponse(http::kBadRequest, config_),
+        static_cast<HTTPRequest *>(NULL)));
+    return Ok(kOk);
+  }
   buf[len] = '\0';
   Result<HTTPRequest *, int> result = parser_.Parser(buf);
   if (result.IsErr() && result.UnwrapErr() == HTTPRequestParser::kNotEnough) {

--- a/src/server/read_request_from_client.hpp
+++ b/src/server/read_request_from_client.hpp
@@ -37,7 +37,7 @@ class ReadRequestFromClient : public AIOTask {
   HTTPRequestParser parser_;
   static const int buf_size_ = 1024;
   enum Responce { kOk, kContinue, kBadRequest };
-  enum Ascii { kEOF = 4 };
+  enum Ascii { kEOT = 4 };
 };
 
 #endif

--- a/src/server/read_request_from_client.hpp
+++ b/src/server/read_request_from_client.hpp
@@ -37,6 +37,7 @@ class ReadRequestFromClient : public AIOTask {
   HTTPRequestParser parser_;
   static const int buf_size_ = 1024;
   enum Responce { kOk, kContinue, kBadRequest };
+  enum Ascii { kEOF = 4 };
 };
 
 #endif


### PR DESCRIPTION
## 1. issue number
#315 サイコーだぜー

## 2. やったこと
telnetで ctl+D を押した時に即BadRequestを返すようにする

nginx挙動
```
kaaaaakun_@kaaaaakun-noMacBook-Air webserv % telnet localhost 8080
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
HTTP/1.1 400 Bad Request
Server: nginx/1.25.4
Date: Thu, 28 Mar 2024 16:39:59 GMT
Content-Type: text/html
Content-Length: 157
Connection: close

<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>nginx/1.25.4</center>
</body>
</html>
Connection closed by foreign host.
```

webserv挙動
```
kaaaaakun_@kaaaaakun-noMacBook-Air webserv % telnet localhost 8002
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
HTTP/1.1 400 Bad Request
Content-Length: 145

<html>
<head><title>400 Bad Request</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<hr><center>webserver</center>
</body>
Connection closed by foreign host.
```

## 3. やらないこと


## 4. 動作確認

  
## 5. 懸念点
errorメッセージ違う方がいい？

## 6. 最近楽しかったこと


## 7. その他
