### PR TITLE
AutoIndexの修正

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -22,7 +22,7 @@ server{
 
     location /red {
         autoindex on;
-        root ./;
+        root ./www/error_page;
     }
 
     location /cgi-bin {

--- a/conf/test.conf
+++ b/conf/test.conf
@@ -42,4 +42,9 @@ server {
     root ./www/test;
     limit_client_body 1000;
   }
+  location /no_index {
+    autoindex on;
+    allow_methods GET;
+    root ./www/test/no_index;
+  }
 }

--- a/src/http/request_handler.cpp
+++ b/src/http/request_handler.cpp
@@ -78,7 +78,6 @@ Option<HTTPResponse *> RequestHandler::Get(const IConfig &config,
 
   if (need_autoindex) {
     // ディレクトリが存在しない場合には404を返す
-    Logger::Debug() << "===============" << request_file_path << std::endl;
     if (!file_utils::DoesFileOrDirectoryExist(request_file_path)) {
       return Some(GenerateErrorResponse(http::kNotFound, config));
     }

--- a/src/http/request_handler.cpp
+++ b/src/http/request_handler.cpp
@@ -77,8 +77,9 @@ Option<HTTPResponse *> RequestHandler::Get(const IConfig &config,
   }
 
   if (need_autoindex) {
-    // ファイルが存在しない場合には404を返す
-    if (!file_utils::CheckIfFileExistsWithoutExecPermission(
+    // ディレクトリが存在しない場合には404を返す
+    Logger::Debug() << "===============" << request_file_path << std::endl;
+    if (!file_utils::DoesFileOrDirectoryExist(
             request_file_path)) {
       return Some(GenerateErrorResponse(http::kNotFound, config));
     }

--- a/src/http/request_handler.cpp
+++ b/src/http/request_handler.cpp
@@ -79,8 +79,7 @@ Option<HTTPResponse *> RequestHandler::Get(const IConfig &config,
   if (need_autoindex) {
     // ディレクトリが存在しない場合には404を返す
     Logger::Debug() << "===============" << request_file_path << std::endl;
-    if (!file_utils::DoesFileOrDirectoryExist(
-            request_file_path)) {
+    if (!file_utils::DoesFileOrDirectoryExist(request_file_path)) {
       return Some(GenerateErrorResponse(http::kNotFound, config));
     }
     // パーミッションがない場合には403を返す

--- a/test/e2e/request/ok_200/auto_index.txt
+++ b/test/e2e/request/ok_200/auto_index.txt
@@ -1,0 +1,3 @@
+GET /no_index/ HTTP/1.1
+Host: localhost:8080
+

--- a/www/test/no_index/hello.html
+++ b/www/test/no_index/hello.html
@@ -1,0 +1,1 @@
+hello world


### PR DESCRIPTION
## 1. issue number
#386 

## 2. やったこと
#382 ここの修正でAutoIndexが動かなくなってたので修正
原因は`file_utils::CheckIfFileExistsWithoutExecPermission`がディレクトリに対してもfalseを返すこと。
`DoesFileOrDirectoryExist`はファイルとディレクトリの区別しないのでそっちを使う

AutoIndexのテストも追加

## 3. やらないこと


## 4. 動作確認

  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
