### PR TITLE
RubyのCGIを追加する close #389

### DIFF
--- a/conf/default.conf
+++ b/conf/default.conf
@@ -29,7 +29,7 @@ server{
         root ./www/html/root.py/cgi-bin;
         allow_methods GET POST DELETE;
         index time.py;
-        cgi_extension .py .sh;
+        cgi_extension .py .sh .rb;
     }
 }
 server{

--- a/www/html/index.html
+++ b/www/html/index.html
@@ -13,6 +13,7 @@
         <li class="item"><a href="/cgi_post.html">CGI POSTのテストはこちら</a></li>
         <li class="item"><a href="/cgi-bin/cookie_test.py">Cookieのテストはこちら</a></li>
         <li class="item"><a href="/cgi-bin/session_test.py">Sessionのテストはこちら</a></li>
+        <li class="item"><a href="/cgi-bin/ruby_cgi.rb">RubyのCGIはこちら</a></li>
         <li class="item"><a href="/red/">AutoIndexのテストはこちら</a></li>
         <li class="item"><a href="/cgi-bin/">時間の確認はこちら</a></li>
     </ul>

--- a/www/html/root.py/cgi-bin/ruby_cgi.rb
+++ b/www/html/root.py/cgi-bin/ruby_cgi.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+require 'cgi'
+
+cgi = CGI.new
+
+cgi.out("content-type" => "text/html") do
+  "<html><head><title>CGI Test</title></head><body>" +
+  "<h1>CGI Test Page</h1>" +
+  "<p>Query Parameters:</p>" +
+  "<ul>" +
+  cgi.params.map { |key, value|
+    "<li>#{key}: #{value.join(', ')}</li>"
+  }.join('') +
+  "</ul>" +
+  "</body></html>"
+end


### PR DESCRIPTION
## 1. issue number
#389 

## 2. やったこと
RubyのCGIを追加する
動かすときにはRubyインストールする必要があります
校舎に入ってたか、入ってなかったら入れることができるのかはわかんないです

## 3. やらないこと


## 4. 動作確認

  
## 5. 懸念点
追加する場所`root.py`じゃない方がいいですか？
Python用に作っていそうだなとは思いつつ追加しちゃいました

## 6. 最近楽しかったこと


## 7. その他
