### PR TITLE
異常終了時のexit statusをゼロ以外にする close #387

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@ int main(int ac, char **av) {
     config_file = av[1];
   else {
     Logger::Error() << "Invalid argument." << std::endl;
-    return 0;
+    return 1;
   }
   Logger::Info() << "Reading " << config_file << std::endl;
   try {
@@ -30,7 +30,10 @@ int main(int ac, char **av) {
          it != m.end(); ++it) {
       Logger::Info() << *it << std::endl;
     }
-    Server::Run(config);
+    if (!Server::Run(config)) {
+      Logger::Error() << "Server::Run() failed." << std::endl;
+      return 1;
+    }
   } catch (std::exception &e) {
     std::cerr << e.what() << std::endl;
     std::exit(1);


### PR DESCRIPTION
## 1. issue number
#387 

## 2. やったこと
異常終了した時のexit statusがゼロの場合があるので、ゼロ以外を返すようにしました

## 3. やらないこと


## 4. 動作確認

  
## 5. 懸念点


## 6. 最近楽しかったこと


## 7. その他
